### PR TITLE
Make search-api hit elasticsearch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ venv
 __pycache__
 .idea/
 *.iml
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ Create a virtual environment
 virtualenv ./venv
  ```
  
-Ensure you have Elasticsearch running locally
+Ensure you have Elasticsearch running locally and then set the required environment variable
+(in production this will point to the load balancer in front of the Elasticsearch cluster).
 
+```
+export DM_ELASTICSEARCH_URL=http://localhost:9200
+```
 
 ### Activate the virtual environment
 

--- a/README.md
+++ b/README.md
@@ -5,24 +5,25 @@ API to handle interactions between the digitalmarketplace applications and searc
 
 ## Setup
 
+Install [elasticsearch](http://www.elasticsearch.org/)
+
+```
+brew update
+brew install elasticsearch
+```
+
 Install [Virtualenv](https://virtualenv.pypa.io/en/latest/)
 
 ```
 sudo easy_install virtualenv
 ```
 
-Create a virtual environment
+Create a virtual environment in the checked-out repository folder
  
  ```
+cd digitalmarketplace-search-api
 virtualenv ./venv
  ```
- 
-Ensure you have Elasticsearch running locally and then set the required environment variable
-(in production this will point to the load balancer in front of the Elasticsearch cluster).
-
-```
-export DM_ELASTICSEARCH_URL=http://localhost:9200
-```
 
 ### Activate the virtual environment
 
@@ -32,9 +33,30 @@ source ./venv/bin/activate
 
 ### Upgrade dependencies
 
-Install new Python dependencies with pip
+Install Python dependencies with pip
 
 ```pip install -r requirements_for_test.txt```
+
+### Insert G6 services into elasticsearch index
+
+Start elasticsearch (in a new console window/tab)
+
+```
+elasticsearch
+```
+
+Index G6 services into your local elasticsearch index:
+
+```
+./scripts/index-g6-in-elasticsearch.py http://localhost:9200/services https://api.digitalmarketplace.service.gov.uk/services <api_bearer_token>
+```
+
+Set the required environment variable (in production this will point to the 
+load balancer in front of the Elasticsearch cluster).
+
+```
+export DM_ELASTICSEARCH_URL=http://localhost:9200
+```
 
 ### Run the tests
 

--- a/app/main/search_result_formatters.py
+++ b/app/main/search_result_formatters.py
@@ -1,0 +1,30 @@
+class SearchResults(object):
+    def __init__(self, results_dict):
+        self.lots = {
+            'IaaS': 'Infrastructure as a Service',
+            'SaaS': 'Software as a Service',
+            'PaaS': 'Platform as a Service',
+            'SCS': 'Specialist Cloud Services'
+        }
+        self.total = results_dict['hits']['total']
+        self.results = []
+        results = results_dict['hits']['hits']
+        for raw_result in results:
+            result = {}
+            for field in raw_result['fields']:
+                result[field] = raw_result['fields'][field][0]
+
+            result['lot'] = self.lots[result['lot']]
+            self.results.append(result)
+
+    def get_services(self):
+        return self.results
+
+    def get_total(self):
+        return {'total': self.total}
+
+    def get_results(self):
+        return {
+            'services': self.get_services(),
+            'total': self.get_total()
+        }

--- a/app/main/search_service.py
+++ b/app/main/search_service.py
@@ -1,0 +1,67 @@
+import os
+from elasticsearch import Elasticsearch
+
+# Setup
+es_url = os.getenv('DM_ELASTICSEARCH_URL')
+es = Elasticsearch(es_url)
+
+
+# Basic keyword query without filters endpoint - may not be required as the
+# filtered query gives the same results if only a keyword query is supplied
+#
+# I'm leaving it here for now though
+#
+# def keyword_query(query, start_from=0, size=10):
+#     res = es.search(index="services",
+#                     body={
+#                         "from": start_from, "size": size,
+#                         "fields": ["id", "serviceName", "lot",
+#                                    "serviceSummary"],
+#                         "query": {
+#                             "multi_match": {
+#                                 "query": query,
+#                                 "fields": ["serviceName",
+#                                            "serviceSummary",
+#                                            "serviceFeatures",
+#                                            "serviceBenefits"],
+#                                 "operator": "or"
+#                             }
+#                         }
+#                     }
+#                     )
+#     return res
+
+
+def keyword_query_with_filters(request_args, start_from=0, size=10):
+    query = request_args["q"]
+    filters = []
+    for k, v in request_args.iteritems():
+        # Do not include the query string as a filter
+        if k == "q":
+            continue
+        filters.append({"term": {k: v.lower()}})
+    res = es.search(index="services",
+                    body={
+                        "from": start_from, "size": size,
+                        "fields": ["id", "serviceName", "lot",
+                                   "serviceSummary"],
+                        "query": {
+                            "filtered": {
+                                "query": {
+                                    "multi_match": {
+                                        "query": query,
+                                        "fields": ["serviceName",
+                                                   "serviceSummary",
+                                                   "serviceFeatures",
+                                                   "serviceBenefits"],
+                                        "operator": "or"
+                                    }
+                                },
+                                "filter": {
+                                    "bool": {"must": filters}
+                                }
+                            }
+                        }
+                    }
+                    )
+    return res

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,5 +1,6 @@
-from . import main
-from flask import jsonify, url_for, Response
+from flask import jsonify, url_for, request
+from . import main, search_service
+from .search_result_formatters import SearchResults
 
 
 @main.route('/')
@@ -14,5 +15,7 @@ def index():
 
 
 @main.route('/search', methods=['GET'])
-def keyword_query():
-    return Response("Not yet implemented... come back later!"), 202
+def keyword_query_with_optional_filters():
+    response = search_service.keyword_query_with_filters(request.args)
+    search_results_obj = SearchResults(response)
+    return jsonify(search_results_obj.get_results())

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -9,7 +9,8 @@ def index():
     return jsonify(links=[
         {
             "rel": "query.gdm.index",
-            "href": url_for('.keyword_query', _external=True)
+            "href": url_for('.keyword_query_with_optional_filters',
+                            _external=True)
         }
     ]), 200
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,14 @@
 Flask==0.10.1
 Flask-Script==2.0.5
+requests==2.5.1
+
+# Required for SNI to work in requests
+pyOpenSSL==0.14
+ndg-httpsclient==0.3.3
+pyasn1==0.1.7
+
+# Elasticsearch 1.0
+elasticsearch>=1.0.0,<2.0.0
 
 #Required for testing
 pep8==1.5.7

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -14,7 +14,3 @@ class TestApplication(BaseApplicationTest):
     def test_404(self):
         response = self.client.get('/not-found')
         assert 404 == response.status_code
-
-    def test_202(self):
-        response = self.client.get('/search?q=email')
-        assert 202 == response.status_code


### PR DESCRIPTION
Adds a single /search endpoint that requires 'q=<query_string>' parameter for the query string, with optional further parameters to specify filters (e.g. "&lot=iaas")