### PR TITLE
Add PEP8 and Nose to the project requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ Flask-Script==2.0.5
 
 # Elasticsearch 1.0
 elasticsearch>=1.0.0,<2.0.0
+
+#Required for testing
+pep8==1.5.7
+nose==1.3.4


### PR DESCRIPTION
The `./scripts/run_tests.sh` script is currently assuming these are installed globally.