### PR TITLE
Pass Auth headers through to application

### DIFF
--- a/.ebextensions/wsgipassauth.config
+++ b/.ebextensions/wsgipassauth.config
@@ -1,0 +1,3 @@
+container_commands:
+  01_wsgipass:
+    command: 'echo "WSGIPassAuthorization On" >> ../wsgi.conf'


### PR DESCRIPTION
The search-api now has proper authentication, so we need to pass the auth headers through to the app.

This is the same as how it is done in the api project:
https://github.com/alphagov/digitalmarketplace-api/blob/master/.ebextensions/wsgipassauth.config