### PR TITLE
Ensured that when a service with no service types is passed to the searc...

### DIFF
--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -32,8 +32,9 @@ def search(index_name, doc_type):
             methods=['POST'])
 def index_document(index_name, doc_type, service_id):
     json_payload = get_json_from_request('service')
-    json_payload['serviceTypesExact'] = \
-        create_exact_service_types(json_payload['serviceTypes'])
+    if 'serviceTypes' in json_payload:
+        json_payload['serviceTypesExact'] = \
+            create_exact_service_types(json_payload['serviceTypes'])
     result = index(
         index_name,
         doc_type,

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Bootstrap virtualenv environment and postgres databases locally.
+#
+# NOTE: This script expects to be run from the project root with
+# ./scripts/bootstrap.sh
+
+set -o pipefail
+
+function display_result {
+  RESULT=$1
+  EXIT_STATUS=$2
+  TEST=$3
+
+  if [ $RESULT -ne 0 ]; then
+    echo -e "\033[31m$TEST failed\033[0m"
+    exit $EXIT_STATUS
+  else
+    echo -e "\033[32m$TEST passed\033[0m"
+  fi
+}
+
+if [ ! $VIRTUAL_ENV ]; then
+  virtualenv ./venv
+  . ./venv/bin/activate
+fi
+
+# Install Python development dependencies
+pip install -r requirements_for_test.txt

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -102,6 +102,18 @@ class TestIndexingDocuments(BaseApplicationTest):
 
         assert_equal(response.status_code, 200)
 
+    def test_should_index_a_document_with_no_service_types(self):
+        service = default_service()
+        service["service"]["serviceName"] = 123
+        del service["service"]["serviceTypes"]
+
+        response = self.client.post(
+            '/index-to-create/services/' + str(service["service"]["id"]),
+            data=json.dumps(service),
+            content_type='application/json')
+
+        assert_equal(response.status_code, 200)
+
 
 # TODO write a load of queries into here for the various fields
 class TestSearchQueries(BaseApplicationTest):


### PR DESCRIPTION
...h API to index, we skip that field and allow indexing of the rest. Note PaaS services have no service types.

This completes https://www.pivotaltracker.com/story/show/92533552

PaaS services have no service types, so don't try and create an exact match array of services types if that data is not present.