### PR TITLE
Fix type error caused by error reporting

### DIFF
--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -19,7 +19,7 @@ def create_index(index_name):
         es.indices.create(index=index_name, body=SERVICES_MAPPING)
         return response(200, "acknowledged")
     except TransportError as e:
-        return response(e.status_code, e.info["error"])
+        return response(e.status_code, e.info)
 
 
 def delete_index(index_name):
@@ -27,7 +27,7 @@ def delete_index(index_name):
         es.indices.delete(index=index_name)
         return response(200, "acknowledged")
     except TransportError as e:
-        return response(e.status_code, e.info["error"])
+        return response(e.status_code, e.info)
 
 
 def fetch_by_id(index_name, doc_type, document_id):
@@ -55,7 +55,7 @@ def index(index_name, doc_type, document, document_id):
             body=document)
         return response(200, "acknowledged")
     except TransportError as e:
-        return response(e.status_code, e.info["error"])
+        return response(e.status_code, e.info)
 
 
 def status_for_index(index_name):
@@ -63,7 +63,7 @@ def status_for_index(index_name):
         res = es.indices.status(index=index_name, human=True)
         return response(200, convert_es_status(res, index_name))
     except TransportError as e:
-        return response(e.status_code, e.info["error"])
+        return response(e.status_code, e.info)
 
 
 def status_for_all_indexes():
@@ -78,4 +78,4 @@ def keyword_search(index_name, doc_type, query_args):
             body=construct_query(query_args))
         return response(200, convert_es_results(res, query_args))
     except TransportError as e:
-        return response(e.status_code, e.info["error"])
+        return response(e.status_code, e.info)


### PR DESCRIPTION
Currently some error messages try to get `exception.info["error"]` but
`exception.info` is a list, not a map, so this results in:
`TypeError: sequence index must be integer, not 'str'`
When reporting errors, and the original error message is lost.