### PR TITLE
Pc database info in status

### DIFF
--- a/app/main/services/response_formatters.py
+++ b/app/main/services/response_formatters.py
@@ -2,6 +2,16 @@ from .query_builder import TEXT_FIELDS
 
 
 def convert_es_status(es_response, index_name):
+    if index_name in ["_all", ""]:
+        return [
+            _convert_es_index_status(es_response, name)
+            for name in es_response["indices"].keys()
+        ]
+    else:
+        return _convert_es_index_status(es_response, index_name)
+
+
+def _convert_es_index_status(es_response, index_name):
     index_status = es_response["indices"][index_name]
 
     status = {}

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -8,13 +8,13 @@ from ..main.services.search_service import status_for_all_indexes
 @status.route('/_status')
 def status():
 
-    db_status = status_for_all_indexes()
+    es_status = status_for_all_indexes()
 
-    if db_status['status_code'] == 200:
+    if es_status['status_code'] == 200:
         return jsonify(
             status="ok",
             version=utils.get_version_label(),
-            db_status=db_status
+            es_status=es_status
         )
 
     current_app.logger.exception("Error connecting to elasticsearch")
@@ -23,8 +23,8 @@ def status():
         status="error",
         version=utils.get_version_label(),
         message="Error connecting to elasticsearch",
-        db_status={
-            'status_code': db_status['status_code'],
-            'message': "{}".format(db_status['message'])
+        es_status={
+            'status_code': es_status['status_code'],
+            'message': "{}".format(es_status['message'])
         }
     ), 500

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,9 +1,27 @@
-from flask import jsonify
+from flask import jsonify, current_app
 
 from . import status
 from . import utils
+from ..main.services.search_service import status_for_all_indexes
 
 
 @status.route('/_status')
 def status():
-    return jsonify(status="ok", version=utils.get_version_label())
+
+    db_status = status_for_all_indexes()
+
+    if db_status['status_code'] == 200:
+        return jsonify(
+            status="ok",
+            version=utils.get_version_label(),
+            db_status=db_status
+        )
+
+    current_app.logger.exception("Error connecting to elasticsearch")
+
+    return jsonify(
+        status="error",
+        version=utils.get_version_label(),
+        message="Error connecting to elasticsearch",
+        db_status=db_status
+    ), 500

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -23,5 +23,8 @@ def status():
         status="error",
         version=utils.get_version_label(),
         message="Error connecting to elasticsearch",
-        db_status=db_status
+        db_status={
+            'status_code': 500,
+            'message': db_status['message'][0]
+        }
     ), 500

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -24,7 +24,7 @@ def status():
         version=utils.get_version_label(),
         message="Error connecting to elasticsearch",
         db_status={
-            'status_code': 500,
-            'message': db_status['message'][0]
+            'status_code': db_status['status_code'],
+            'message': "{}".format(db_status['message'])
         }
     ), 500


### PR DESCRIPTION
Update the `_status` endpoint to indicate a connection to elasticsearch.
Everything going well returns something like this:
```json
{
  "db_status": {
    "message": [
      {
        "num_docs": 16423, 
        "primary_size": "26mb"
      }
    ], 
    "status_code": 200
  }, 
  "status": "ok", 
  "version": null
}
```

Elasticsearch not connected, but API still running:
```json
{
  "db_status": {
    "message": "Connection aborted.", 
    "status_code": 500
  }, 
  "message": "Error connecting to elasticsearch", 
  "status": "error", 
  "version": null
}
```

And, obviously, if the API isn't running then nothing happens.

![screen shot 2015-05-05 at 14 18 04](https://cloud.githubusercontent.com/assets/2454380/7473242/9eb087c8-f331-11e4-9d3d-f97da4a29a8f.png)
