### PR TITLE
Replace wsgipassauth cmd with elasticbeanstalk config/deploy hook

### DIFF
--- a/.ebextensions/wsgipassauth.config
+++ b/.ebextensions/wsgipassauth.config
@@ -1,3 +1,26 @@
-container_commands:
-  01_wsgipass:
-    command: 'echo "WSGIPassAuthorization On" >> ../wsgi.conf'
+commands:
+  create_app_hook_pre_dir:
+    command: "mkdir -p /opt/elasticbeanstalk/hooks/appdeploy/pre"
+    ignoreErrors: true
+
+  create_config_hook_pre_dir:
+    command: "mkdir -p /opt/elasticbeanstalk/hooks/configdeploy/pre"
+    ignoreErrors: true
+
+files:
+  "/opt/elasticbeanstalk/hooks/appdeploy/pre/99wsgipassauth.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      WSGI_FILE_PATH=$(/opt/elasticbeanstalk/bin/get-config container -k 'wsgi_staging_config')
+      echo 'WSGIPassAuthorization On' >> "$WSGI_FILE_PATH"
+  "/opt/elasticbeanstalk/hooks/configdeploy/pre/99wsgipassauth.sh":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/usr/bin/env bash
+      WSGI_FILE_PATH=$(/opt/elasticbeanstalk/bin/get-config container -k 'wsgi_staging_config')
+      echo 'WSGIPassAuthorization On' >> "$WSGI_FILE_PATH"


### PR DESCRIPTION
Default elasticbeanstalk apache config doesn't set WSGIPassAuthorization,
which means that Authorization header isn't forwarded to the app,
so we need a way to modify the config ourselves. Unfortunately, there's
no documented way to do this.

Our previous solution used a container_command to add a line to
wsgi.conf. This works for deployments, but configuration changes
triggered through the AWS interface or Cloudformation updates
rewrite the wsgi.conf without executing container commands, so we needed
to run a redeploy immediately after config change to fix the PassAuth.

There's another solution described in http://stackoverflow.com/a/29031663
that patches the elasticbeanstalk code responsible for generating the
apache config. While that fixes the configuration change issue, the
solution seems brittle (it relies on the fact that template config
is in the config.py file and that it contains a certain line).

Looking closer at the /opt/elasticbeanstalk/hooks on the EB instances,
there are folders with pre and post hooks for config changes and app
deploys. So we use them to add additional hook files for both.
The additional file is a pre-hook, that looks up the temporary
wsgi.conf file location using the same method existing hooks use
and adds a WSGIPassAuthorization line to it. The file is then moved
into place by the enact elasticbeanstalk hooks.

Since the file is recreated each time it's safe to append to it.