### PR TITLE
Page size and pagination

### DIFF
--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -108,7 +108,7 @@ class QueryFilter(object):
             })
 
 
-def construct_query(query_args, page=100):
+def construct_query(query_args, page_size=100):
     if not is_filtered(query_args):
         query = {
             "query": build_keywords_query(query_args)
@@ -125,9 +125,12 @@ def construct_query(query_args, page=100):
         }
     query["highlight"] = highlight_clause()
 
-    query["size"] = page
-    if "from" in query_args:
-        query["from"] = query_args.get("from")
+    query["size"] = page_size
+    if "page" in query_args:
+        try:
+            query["from"] = (int(query_args.get("page")) - 1) * page_size
+        except ValueError:
+            raise ValueError("Invalid page {}".format(query_args.get("page")))
 
     return query
 

--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -108,7 +108,7 @@ class QueryFilter(object):
             })
 
 
-def construct_query(query_args):
+def construct_query(query_args, page_size=100):
     if not is_filtered(query_args):
         query = {
             "query": build_keywords_query(query_args)
@@ -124,6 +124,11 @@ def construct_query(query_args):
 
         }
     query["highlight"] = highlight_clause()
+
+    query["size"] = page_size
+    if "from" in query_args:
+        query["from"] = query_args.get("from")
+
     return query
 
 

--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -108,7 +108,7 @@ class QueryFilter(object):
             })
 
 
-def construct_query(query_args, page_size=100):
+def construct_query(query_args, page=100):
     if not is_filtered(query_args):
         query = {
             "query": build_keywords_query(query_args)
@@ -125,7 +125,7 @@ def construct_query(query_args, page_size=100):
         }
     query["highlight"] = highlight_clause()
 
-    query["size"] = page_size
+    query["size"] = page
     if "from" in query_args:
         query["from"] = query_args.get("from")
 

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -5,6 +5,7 @@ from app.mapping import SERVICES_MAPPING
 from app.main.services.response_formatters import \
     convert_es_status, convert_es_results
 from app.main.services.query_builder import construct_query
+from flask import current_app
 
 es_url = os.getenv('DM_ELASTICSEARCH_URL')
 es = Elasticsearch(es_url)
@@ -75,7 +76,10 @@ def keyword_search(index_name, doc_type, query_args):
         res = es.search(
             index=index_name,
             doc_type=doc_type,
-            body=construct_query(query_args))
+            body=construct_query(
+                query_args,
+                current_app.config['DM_SEARCH_PAGE_SIZE'])
+        )
         return response(200, convert_es_results(res, query_args))
     except TransportError as e:
         return response(e.status_code, _get_an_error_message(e))

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -11,6 +11,10 @@ es_url = os.getenv('DM_ELASTICSEARCH_URL')
 es = Elasticsearch(es_url)
 
 
+def refresh(index_name):
+    return es.indices.refresh(index_name)
+
+
 def response(status_code, message):
     return {"status_code": status_code, "message": message}
 

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -87,6 +87,8 @@ def keyword_search(index_name, doc_type, query_args):
         return response(200, convert_es_results(res, query_args))
     except TransportError as e:
         return response(e.status_code, _get_an_error_message(e))
+    except ValueError as e:
+        return response(400, e.message)
 
 
 def _get_an_error_message(exception):

--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 class Config:
     AUTH_REQUIRED = True
     ALLOW_EXPLORER = True
-
+    DM_SEARCH_PAGE_SIZE = 100
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
     DM_APP_NAME = 'search-api'

--- a/tests/app/services/test_query_builder.py
+++ b/tests/app/services/test_query_builder.py
@@ -18,7 +18,8 @@ def test_should_be_able_to_override_pagesize():
 
 
 def test_should_have_from_set():
-    assert_equal(construct_query(build_query_params(from_param=100))["from"], 100)
+    assert_equal(
+        construct_query(build_query_params(from_param=100))["from"], 100)
 
 
 def test_should_have_no_from_by_default():
@@ -48,12 +49,7 @@ def test_should_make_multi_match_query_if_keywords_supplied():
         "serviceBenefits",
         "serviceTypes",
         "supplierName"
-<<<<<<< HEAD
     ])
-=======
-    ]
-                 )
->>>>>>> Adding page size and from params to query builder
 
 
 def test_should_identify_filter_search_from_query_params():
@@ -106,12 +102,7 @@ def test_should_have_filtered_root_element_and_match_keywords():
         "serviceBenefits",
         "serviceTypes",
         "supplierName"
-<<<<<<< HEAD
     ])
-=======
-    ]
-                 )
->>>>>>> Adding page size and from params to query builder
 
 
 def test_should_have_filtered_term_service_types_clause():
@@ -227,30 +218,17 @@ def test_highlight_block_contains_correct_fields():
             example
 
 
-<<<<<<< HEAD
-def build_query_params(keywords=None, service_types=None, lot=None):
+def build_query_params(keywords=None, service_types=None, lot=None,
+                       from_param=None):
     query_params = MultiDict()
-=======
-# TODO convert to ImmutableDict
-def build_query_params(
-        keywords=None,
-        service_types=None,
-        lot=None,
-        from_param=None):
-    query_params = {}
->>>>>>> Adding page size and from params to query builder
     if keywords:
         query_params["q"] = keywords
     if service_types:
         for service_type in service_types:
             query_params.add("filter_serviceTypes", service_type)
     if lot:
-<<<<<<< HEAD
         query_params["filter_lot"] = lot
-
-=======
         query_params["lot"] = lot
     if from_param:
         query_params["from"] = from_param
->>>>>>> Adding page size and from params to query builder
     return query_params

--- a/tests/app/services/test_query_builder.py
+++ b/tests/app/services/test_query_builder.py
@@ -1,5 +1,5 @@
 import types
-from nose.tools import assert_equal, assert_in, assert_not_in
+from nose.tools import assert_equal, assert_in, assert_not_in, assert_false
 from app.main.services.query_builder import construct_query, \
     is_filtered
 from werkzeug.datastructures import MultiDict
@@ -7,6 +7,22 @@ from werkzeug.datastructures import MultiDict
 
 def test_should_have_correct_root_element():
     assert_equal("query" in construct_query(build_query_params()), True)
+
+
+def test_should_have_page_size_set():
+    assert_equal(construct_query(build_query_params())["size"], 100)
+
+
+def test_should_be_able_to_override_pagesize():
+    assert_equal(construct_query(build_query_params(), 10)["size"], 10)
+
+
+def test_should_have_from_set():
+    assert_equal(construct_query(build_query_params(from_param=100))["from"], 100)
+
+
+def test_should_have_no_from_by_default():
+    assert_false("from" in construct_query(build_query_params()))
 
 
 def test_should_have_match_all_query_if_no_params():
@@ -32,7 +48,12 @@ def test_should_make_multi_match_query_if_keywords_supplied():
         "serviceBenefits",
         "serviceTypes",
         "supplierName"
+<<<<<<< HEAD
     ])
+=======
+    ]
+                 )
+>>>>>>> Adding page size and from params to query builder
 
 
 def test_should_identify_filter_search_from_query_params():
@@ -85,7 +106,12 @@ def test_should_have_filtered_root_element_and_match_keywords():
         "serviceBenefits",
         "serviceTypes",
         "supplierName"
+<<<<<<< HEAD
     ])
+=======
+    ]
+                 )
+>>>>>>> Adding page size and from params to query builder
 
 
 def test_should_have_filtered_term_service_types_clause():
@@ -201,14 +227,30 @@ def test_highlight_block_contains_correct_fields():
             example
 
 
+<<<<<<< HEAD
 def build_query_params(keywords=None, service_types=None, lot=None):
     query_params = MultiDict()
+=======
+# TODO convert to ImmutableDict
+def build_query_params(
+        keywords=None,
+        service_types=None,
+        lot=None,
+        from_param=None):
+    query_params = {}
+>>>>>>> Adding page size and from params to query builder
     if keywords:
         query_params["q"] = keywords
     if service_types:
         for service_type in service_types:
             query_params.add("filter_serviceTypes", service_type)
     if lot:
+<<<<<<< HEAD
         query_params["filter_lot"] = lot
 
+=======
+        query_params["lot"] = lot
+    if from_param:
+        query_params["from"] = from_param
+>>>>>>> Adding page size and from params to query builder
     return query_params

--- a/tests/app/services/test_query_builder.py
+++ b/tests/app/services/test_query_builder.py
@@ -1,4 +1,3 @@
-import types
 from nose.tools import assert_equal, assert_in, assert_not_in, assert_false
 from app.main.services.query_builder import construct_query, \
     is_filtered
@@ -17,9 +16,9 @@ def test_should_be_able_to_override_pagesize():
     assert_equal(construct_query(build_query_params(), 10)["size"], 10)
 
 
-def test_should_have_from_set():
+def test_page_should_set_from_parameter():
     assert_equal(
-        construct_query(build_query_params(from_param=100))["from"], 100)
+        construct_query(build_query_params(page=2))["from"], 100)
 
 
 def test_should_have_no_from_by_default():
@@ -218,8 +217,7 @@ def test_highlight_block_contains_correct_fields():
             example
 
 
-def build_query_params(keywords=None, service_types=None, lot=None,
-                       from_param=None):
+def build_query_params(keywords=None, service_types=None, lot=None, page=None):
     query_params = MultiDict()
     if keywords:
         query_params["q"] = keywords
@@ -229,6 +227,6 @@ def build_query_params(keywords=None, service_types=None, lot=None,
     if lot:
         query_params["filter_lot"] = lot
         query_params["lot"] = lot
-    if from_param:
-        query_params["from"] = from_param
+    if page:
+        query_params["page"] = page
     return query_params

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -125,7 +125,8 @@ class TestSearchQueries(BaseApplicationTest):
             services = create_services(10)
             for service in services:
                 self.client.post(
-                    '/index-to-create/services/' + str(service["service"]["id"]),
+                    '/index-to-create/services/'
+                    + str(service["service"]["id"]),
                     data=json.dumps(service),
                     content_type='application/json')
             time.sleep(5)
@@ -142,17 +143,21 @@ class TestSearchQueries(BaseApplicationTest):
             response = self.client.get(
                 '/index-to-create/services/search?q=serviceName')
             assert_equal(response.status_code, 200)
-            assert_equal(get_json_from_response(response)["search"]["total"], 10)
+            assert_equal(
+                get_json_from_response(response)["search"]["total"], 10)
 
     def test_should_get_services_up_to_page_size(self):
         with self.app.app_context():
             self.app.config['DM_SEARCH_PAGE_SIZE'] = '5'
 
             response = self.client.get(
-                '/index-to-create/services/search?q=serviceName')
+                '/index-to-create/services/search?q=serviceName'
+            )
             assert_equal(response.status_code, 200)
-            assert_equal(get_json_from_response(response)["search"]["total"], 10)
-            assert_equal(len(get_json_from_response(response)["search"]["services"]), 5)
+            assert_equal(
+                get_json_from_response(response)["search"]["total"], 10)
+            assert_equal(
+                len(get_json_from_response(response)["search"]["services"]), 5)
 
     def test_should_get_services_next_page_of_services(self):
         with self.app.app_context():
@@ -160,8 +165,10 @@ class TestSearchQueries(BaseApplicationTest):
             response = self.client.get(
                 '/index-to-create/services/search?q=serviceName&from=5')
             assert_equal(response.status_code, 200)
-            assert_equal(get_json_from_response(response)["search"]["total"], 10)
-            assert_equal(len(get_json_from_response(response)["search"]["services"]), 5)
+            assert_equal(
+                get_json_from_response(response)["search"]["total"], 10)
+            assert_equal(
+                len(get_json_from_response(response)["search"]["services"]), 5)
 
     def test_should_get_no_services_on_out_of_bounds_from(self):
         with self.app.app_context():
@@ -169,8 +176,10 @@ class TestSearchQueries(BaseApplicationTest):
             response = self.client.get(
                 '/index-to-create/services/search?q=serviceName&from=10')
             assert_equal(response.status_code, 200)
-            assert_equal(get_json_from_response(response)["search"]["total"], 10)
-            assert_equal(len(get_json_from_response(response)["search"]["services"]), 0)
+            assert_equal(
+                get_json_from_response(response)["search"]["total"], 10)
+            assert_equal(
+                len(get_json_from_response(response)["search"]["services"]), 0)
 
     def test_should_get_no_services_on_out_of_bounds_from(self):
         with self.app.app_context():
@@ -178,8 +187,10 @@ class TestSearchQueries(BaseApplicationTest):
             response = self.client.get(
                 '/index-to-create/services/search?q=serviceName&from=10')
             assert_equal(response.status_code, 200)
-            assert_equal(get_json_from_response(response)["search"]["total"], 10)
-            assert_equal(len(get_json_from_response(response)["search"]["services"]), 0)
+            assert_equal(
+                get_json_from_response(response)["search"]["total"], 10)
+            assert_equal(
+                len(get_json_from_response(response)["search"]["services"]), 0)
 
     def test_should_get_400_response__on_negative_index(self):
         with self.app.app_context():

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -119,6 +119,17 @@ class TestIndexingDocuments(BaseApplicationTest):
 
 # TODO write a load of queries into here for the various fields
 class TestSearchQueries(BaseApplicationTest):
+    def setup(self):
+        super(TestSearchQueries, self).setup()
+        with self.app.app_context():
+            services = create_services(10)
+            for service in services:
+                self.client.post(
+                    '/index-to-create/services/' + str(service["service"]["id"]),
+                    data=json.dumps(service),
+                    content_type='application/json')
+            time.sleep(5)
+
     def test_should_return_service_on_keyword_search(self):
         service = default_service()
         self.client.put(
@@ -126,11 +137,56 @@ class TestSearchQueries(BaseApplicationTest):
             data=json.dumps(service),
             content_type='application/json')
 
-        time.sleep(5)
-        response = self.client.get(
-            '/index-to-create/services/search?q=serviceName')
-        assert_equal(response.status_code, 200)
-        assert_equal(get_json_from_response(response)["search"]["total"], 1)
+    def test_should_return_service_on_keyword_search(self):
+        with self.app.app_context():
+            response = self.client.get(
+                '/index-to-create/services/search?q=serviceName')
+            assert_equal(response.status_code, 200)
+            assert_equal(get_json_from_response(response)["search"]["total"], 10)
+
+    def test_should_get_services_up_to_page_size(self):
+        with self.app.app_context():
+            self.app.config['DM_SEARCH_PAGE_SIZE'] = '5'
+
+            response = self.client.get(
+                '/index-to-create/services/search?q=serviceName')
+            assert_equal(response.status_code, 200)
+            assert_equal(get_json_from_response(response)["search"]["total"], 10)
+            assert_equal(len(get_json_from_response(response)["search"]["services"]), 5)
+
+    def test_should_get_services_next_page_of_services(self):
+        with self.app.app_context():
+            self.app.config['DM_SEARCH_PAGE_SIZE'] = '5'
+            response = self.client.get(
+                '/index-to-create/services/search?q=serviceName&from=5')
+            assert_equal(response.status_code, 200)
+            assert_equal(get_json_from_response(response)["search"]["total"], 10)
+            assert_equal(len(get_json_from_response(response)["search"]["services"]), 5)
+
+    def test_should_get_no_services_on_out_of_bounds_from(self):
+        with self.app.app_context():
+            self.app.config['DM_SEARCH_PAGE_SIZE'] = '5'
+            response = self.client.get(
+                '/index-to-create/services/search?q=serviceName&from=10')
+            assert_equal(response.status_code, 200)
+            assert_equal(get_json_from_response(response)["search"]["total"], 10)
+            assert_equal(len(get_json_from_response(response)["search"]["services"]), 0)
+
+    def test_should_get_no_services_on_out_of_bounds_from(self):
+        with self.app.app_context():
+            self.app.config['DM_SEARCH_PAGE_SIZE'] = '5'
+            response = self.client.get(
+                '/index-to-create/services/search?q=serviceName&from=10')
+            assert_equal(response.status_code, 200)
+            assert_equal(get_json_from_response(response)["search"]["total"], 10)
+            assert_equal(len(get_json_from_response(response)["search"]["services"]), 0)
+
+    def test_should_get_400_response__on_negative_index(self):
+        with self.app.app_context():
+            self.app.config['DM_SEARCH_PAGE_SIZE'] = '5'
+            response = self.client.get(
+                '/index-to-create/services/search?q=serviceName&from=-10')
+            assert_equal(response.status_code, 400)
 
 
 class TestFetchById(BaseApplicationTest):
@@ -272,6 +328,16 @@ class TestDeleteById(BaseApplicationTest):
         data = get_json_from_response(response)
         assert_equal(response.status_code, 404)
         assert_equal(data['services']['found'], False)
+
+
+def create_services(number_of_services):
+    services = []
+    for i in range(number_of_services):
+        service = default_service()
+        service["service"]["id"] = str(i)
+        services.append(service)
+
+    return services
 
 
 def default_service():

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -124,14 +124,14 @@ class TestSearchQueries(BaseApplicationTest):
         with self.app.app_context():
             services = create_services(10)
             for service in services:
-                self.client.post(
+                self.client.put(
                     '/index-to-create/services/'
                     + str(service["service"]["id"]),
                     data=json.dumps(service),
                     content_type='application/json')
             search_service.refresh('index-to-create')
 
-    def test_should_return_service_on_keyword_search(self):
+    def test_should_return_service_on_id(self):
         service = default_service()
         self.client.put(
             '/index-to-create/services/' + str(service["service"]["id"]),

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -1,5 +1,5 @@
-from app.main.services.conversions import strip_and_lowercase
 from app.main.services.process_request_json import process_values_for_matching
+from app.main.services import search_service
 from flask import json
 import time
 from nose.tools import assert_equal
@@ -64,7 +64,7 @@ class TestIndexingDocuments(BaseApplicationTest):
 
         assert_equal(response.status_code, 200)
 
-        time.sleep(5)  # needs time to propagate???
+        search_service.refresh('index-to-create')
         response = self.client.get('/index-to-create/status')
         assert_equal(response.status_code, 200)
         assert_equal(
@@ -129,7 +129,7 @@ class TestSearchQueries(BaseApplicationTest):
                     + str(service["service"]["id"]),
                     data=json.dumps(service),
                     content_type='application/json')
-            time.sleep(5)
+            search_service.refresh('index-to-create')
 
     def test_should_return_service_on_keyword_search(self):
         service = default_service()
@@ -215,7 +215,8 @@ class TestFetchById(BaseApplicationTest):
             content_type='application/json'
         )
 
-        time.sleep(5)
+        search_service.refresh('index-to-create')
+
         response = self.client.get(
             '/index-to-create/services/' + str(service["service"]["id"]))
 
@@ -316,7 +317,7 @@ class TestDeleteById(BaseApplicationTest):
             content_type='application/json'
         )
 
-        time.sleep(5)
+        search_service.refresh('index-to-create')
         response = self.client.delete(
             '/index-to-create/services/' + str(service["service"]["id"]))
 

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -174,29 +174,25 @@ class TestSearchQueries(BaseApplicationTest):
         with self.app.app_context():
             self.app.config['DM_SEARCH_PAGE_SIZE'] = '5'
             response = self.client.get(
-                '/index-to-create/services/search?q=serviceName&from=10')
+                '/index-to-create/services/search?q=serviceName&page=3')
             assert_equal(response.status_code, 200)
             assert_equal(
                 get_json_from_response(response)["search"]["total"], 10)
             assert_equal(
                 len(get_json_from_response(response)["search"]["services"]), 0)
 
-    def test_should_get_no_services_on_out_of_bounds_from(self):
+    def test_should_get_400_response__on_negative_page(self):
         with self.app.app_context():
             self.app.config['DM_SEARCH_PAGE_SIZE'] = '5'
             response = self.client.get(
-                '/index-to-create/services/search?q=serviceName&from=10')
-            assert_equal(response.status_code, 200)
-            assert_equal(
-                get_json_from_response(response)["search"]["total"], 10)
-            assert_equal(
-                len(get_json_from_response(response)["search"]["services"]), 0)
+                '/index-to-create/services/search?q=serviceName&page=-1')
+            assert_equal(response.status_code, 400)
 
-    def test_should_get_400_response__on_negative_index(self):
+    def test_should_get_400_response__on_non_numeric_page(self):
         with self.app.app_context():
             self.app.config['DM_SEARCH_PAGE_SIZE'] = '5'
             response = self.client.get(
-                '/index-to-create/services/search?q=serviceName&from=-10')
+                '/index-to-create/services/search?q=serviceName&page=foo')
             assert_equal(response.status_code, 400)
 
 


### PR DESCRIPTION
Added `page` and `page_size` to the query builder.

- `page_size` controls how much services should be returned in each page (Configured in the app config)
- `page` specifies which page of results should be returned