### PR TITLE
Indexing framework name

### DIFF
--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -9,7 +9,8 @@ TEXT_FIELDS = [
     "serviceFeatures",
     "serviceBenefits",
     "serviceTypes",
-    "supplierName"
+    "supplierName",
+    "frameworkName"
 ]
 
 FILTER_FIELDS = [

--- a/example_es_responses/search_results.json
+++ b/example_es_responses/search_results.json
@@ -13,6 +13,7 @@
         "_source": {
           "id": "5390159512076288",
           "lot": "SaaS",
+          "frameworkName": "G-Cloud 6",
           "serviceBenefits": [
             "Increase email deliverability",
             "Reduce bogus registrations",
@@ -64,6 +65,7 @@
         "_source": {
           "id": "6446043935801344",
           "lot": "SCS",
+          "frameworkName": "G-Cloud 6",
           "serviceBenefits": [
             "Creativity to achieve cut-through",
             "Advanced Targeting and Segmentation",
@@ -123,6 +125,7 @@
         "_source": {
           "id": "4514646266478592",
           "lot": "SCS",
+          "frameworkName": "G-Cloud 6",
           "serviceBenefits": [
             "User messaging options",
             "Intergrated email support"
@@ -172,6 +175,7 @@
         "_source": {
           "id": "5766140261302272",
           "lot": "SaaS",
+          "frameworkName": "G-Cloud 6",
           "serviceBenefits": [
             "Secure, managed service ",
             "Fully resilient service ",
@@ -215,6 +219,7 @@
         "_source": {
           "id": "4573911983325184",
           "lot": "SCS",
+          "frameworkName": "G-Cloud 6",
           "serviceBenefits": [
             "Unlimited Storage as standard ",
             "Achieve Legal and Compliance targets",
@@ -261,6 +266,7 @@
         "_source": {
           "id": "5034117041225728",
           "lot": "SaaS",
+          "frameworkName": "G-Cloud 6",
           "serviceBenefits": [
             "Reduced IT infrastructure costs",
             "Enhanced security",
@@ -306,6 +312,7 @@
         "_source": {
           "id": "5309011876380672",
           "lot": "SCS",
+          "frameworkName": "G-Cloud 6",
           "serviceBenefits": [
             "Ensures predictable outcomes, minimised risk, maximised productivity during technology change",
             "Accelerated ability to use enhanced capabilities of Microsoft Exchange ",
@@ -356,6 +363,7 @@
         "_source": {
           "id": "5365560355323904",
           "lot": "SaaS",
+          "frameworkName": "G-Cloud 6",
           "serviceBenefits": [
             "Stop malicious or unwanted email from ever reaching your ",
             "Prevents malicious URLs in emails from affecting end users",
@@ -420,6 +428,7 @@
         "_source": {
           "id": "6082103036870656",
           "lot": "SaaS",
+          "frameworkName": "G-Cloud 6",
           "serviceBenefits": [
             "Inbox success",
             "IP pool flexibility",
@@ -470,6 +479,7 @@
         "_source": {
           "id": "6433200507191296",
           "lot": "SaaS",
+          "frameworkName": "G-Cloud 6",
           "serviceBenefits": [
             "Bottomless user mailboxes",
             "Personal archive access from Outlook, MAC, tablet and mobile devices",

--- a/mappings/services.json
+++ b/mappings/services.json
@@ -10,6 +10,9 @@
           "type": "string",
           "index": "not_analyzed"
         },
+        "frameworkName": {
+          "type": "string"
+        },
         "serviceName": {
           "type": "string"
         },

--- a/mappings/services.json
+++ b/mappings/services.json
@@ -11,7 +11,8 @@
           "index": "not_analyzed"
         },
         "frameworkName": {
-          "type": "string"
+          "type": "string",
+          "index": "not_analyzed"
         },
         "serviceName": {
           "type": "string"

--- a/tests/app/services/test_query_builder.py
+++ b/tests/app/services/test_query_builder.py
@@ -31,7 +31,8 @@ def test_should_make_multi_match_query_if_keywords_supplied():
         "serviceFeatures",
         "serviceBenefits",
         "serviceTypes",
-        "supplierName"
+        "supplierName",
+        "frameworkName"
     ])
 
 
@@ -84,7 +85,8 @@ def test_should_have_filtered_root_element_and_match_keywords():
         "serviceFeatures",
         "serviceBenefits",
         "serviceTypes",
-        "supplierName"
+        "supplierName",
+        "frameworkName"
     ])
 
 

--- a/tests/app/services/test_response_formatters.py
+++ b/tests/app/services/test_response_formatters.py
@@ -27,6 +27,7 @@ def test_should_build_search_response_from_es_response():
 
     assert_equal(res["services"][0]["id"], "5390159512076288")
     assert_equal(res["services"][0]["lot"], "SaaS")
+    assert_equal(res["services"][0]["frameworkName"], "G-Cloud 6")
     assert_equal(res["services"][0]["supplierName"], "Supplier Name")
     assert_equal(res["services"][0]["serviceName"], "Email Verification")
     assert_equal(res["services"][0]["serviceTypes"], [

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -31,16 +31,16 @@ class TestSearchIndexes(BaseApplicationTest):
         response = self.client.put('/index-to-create')
         assert_equal(response.status_code, 400)
         assert_equal(
-            get_json_from_response(response)["results"],
-            "IndexAlreadyExistsException[[index-to-create] already exists]")
+            "IndexAlreadyExistsException[[index-to-create] already exists]"
+            in get_json_from_response(response)["results"], True)
 
     def test_should_not_be_able_delete_index_twice(self):
         self.client.put('/index-to-create')
         self.client.delete('/index-to-create')
         response = self.client.delete('/index-to-create')
         assert_equal(response.status_code, 404)
-        assert_equal(get_json_from_response(response)["results"],
-                     "IndexMissingException[[index-to-create] missing]")
+        assert_equal("IndexMissingException[[index-to-create] missing]"
+                     in get_json_from_response(response)["results"], True)
 
     def test_should_return_404_if_no_index(self):
         response = self.client.get('/index-does-not-exist/status')


### PR DESCRIPTION
this pull request adds framework name to the search index and returns it in a search result.
this is so we can render this on a search results page without hitting the data API for each service.

Requires the following 2 pull requests to be merged in order for this to be viable.

https://github.com/alphagov/digitalmarketplace-utils/pull/26

https://github.com/alphagov/digitalmarketplace-api/pull/116

Part of: https://www.pivotaltracker.com/story/show/94070088