### PR TITLE
Make the tags for highlighting match our pattern

### DIFF
--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -129,7 +129,10 @@ def construct_query(query_args):
 
 
 def highlight_clause():
-    highlights = dict()
+    highlights = dict({
+        "pre_tags": ["<em class='search-result-highlighted-text'>"],
+        "post_tags": ["</em>"]
+    })
     highlights["fields"] = {}
 
     for field in TEXT_FIELDS:


### PR DESCRIPTION
We already have a HTML pattern for [highlighting in
search results]
(http://alphagov.github.io/digitalmarketplace-frontend-toolkit/search-result.html) in the Digital Marketplace Front-end 
toolkit. This makes Elasticsearch output to that pattern.