### PR TITLE
Fix test failure on master

### DIFF
--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -209,26 +209,29 @@ class TestSearchQueries(BaseApplicationTest):
             assert_equal(response.status_code, 400)
 
     def test_highlighting_should_use_defined_html_tags(self):
-        service = default_service()
-        service["service"]['serviceSummary'] = \
-            u"Accessing, storing and retaining email"
-        highlighted_summary = \
-            "Accessing, <em class='search-result-highlighted-text'>storing" +\
-            "</em> and retaining email"
-        self.client.put(
-            '/index-to-create/services/' + str(service["service"]["id"]),
-            data=json.dumps(service),
-            content_type='application/json')
+        with self.app.app_context():
+            service = default_service()
+            service["service"]['serviceSummary'] = \
+                u"Accessing, storing and retaining email"
+            highlighted_summary = \
+                "Accessing, <em class='search-result-highlighted-text'>" +\
+                "storing</em> and retaining email"
+            self.client.put(
+                '/index-to-create/services/' + str(service["service"]["id"]),
+                data=json.dumps(service),
+                content_type='application/json')
+            search_service.refresh('index-to-create')
 
-        time.sleep(5)
-        response = self.client.get(
-            '/index-to-create/services/search?q=storing')
-        assert_equal(response.status_code, 200)
-        search_results = get_json_from_response(response)["search"]["services"]
-        assert_equal(
-            search_results[0]["highlight"]["serviceSummary"][0],
-            highlighted_summary
-        )
+            response = self.client.get(
+                '/index-to-create/services/search?q=storing')
+            assert_equal(response.status_code, 200)
+            search_results = get_json_from_response(
+                response
+            )["search"]["services"]
+            assert_equal(
+                search_results[0]["highlight"]["serviceSummary"][0],
+                highlighted_summary
+            )
 
 
 class TestFetchById(BaseApplicationTest):


### PR DESCRIPTION
The pull request #35 failed when merged into master because the time
package is no longer imported. Newer tests have been written using the
`refresh` method instead.