### PR TITLE
Fix broken status endpoint

### DIFF
--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -114,7 +114,7 @@ def _get_an_error_message(exception):
         return exception
     try:
         error = info['error']
-    except KeyError:
+    except (KeyError, TypeError):
         return info
 
     return error

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -7,14 +7,13 @@ from ..main.services.search_service import status_for_all_indexes
 
 @status.route('/_status')
 def status():
+    result, status_code = status_for_all_indexes()
 
-    es_status = status_for_all_indexes()
-
-    if es_status['status_code'] == 200:
+    if status_code == 200:
         return jsonify(
             status="ok",
             version=utils.get_version_label(),
-            es_status=es_status
+            es_status=result,
         )
 
     current_app.logger.exception("Error connecting to elasticsearch")
@@ -24,7 +23,7 @@ def status():
         version=utils.get_version_label(),
         message="Error connecting to elasticsearch",
         es_status={
-            'status_code': es_status['status_code'],
-            'message': "{}".format(es_status['message'])
+            'status_code': status_code,
+            'message': "{}".format(result),
         }
     ), 500

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 nose==1.3.4
 pep8==1.5.7
+mock==1.0.1

--- a/tests/app/views/test_status.py
+++ b/tests/app/views/test_status.py
@@ -1,0 +1,26 @@
+import json
+
+from nose.tools import assert_equal
+import mock
+from elasticsearch import TransportError
+
+from ..helpers import BaseApplicationTest
+
+
+class TestStatus(BaseApplicationTest):
+    def test_status(self):
+        with self.app.app_context():
+            response = self.client.get('/_status')
+
+            assert_equal(response.status_code, 200)
+
+    @mock.patch('app.main.services.search_service.es.indices.status')
+    def test_status_when_elasticsearch_is_down(self, status):
+        with self.app.app_context():
+            status.side_effect = TransportError(500, "BARR", "FOO")
+            response = self.client.get('/_status')
+
+            assert_equal(response.status_code, 500)
+
+            data = json.loads(response.data.decode('utf-8'))
+            assert_equal(data['es_status']['message'], "FOO")


### PR DESCRIPTION
In https://github.com/alphagov/digitalmarketplace-search-api/pull/34 I changed the way the search service functions returned multiple responses. However, I forgot to make the required change in the status view.

I've also added a minimal test of the status endpoint.