### PR TITLE
Add search filter tests

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,7 +20,7 @@ class Config:
 
 
 class Test(Config):
-    DEBUG = True,
+    DEBUG = True
     DM_LOG_LEVEL = 'CRITICAL'
 
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -30,5 +30,5 @@ function display_result {
 pep8 .
 display_result $? 1 "Code style check"
 
-nosetests -v -s --with-doctest
+nosetests -v -s --with-doctest --logging-level=CRITICAL
 display_result $? 2 "Unit tests"

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -23,29 +23,27 @@ class BaseApplicationTest(object):
         self.client = self.app.test_client()
         self.default_index_name = "index-to-create"
 
-        self.setup_authorization()
-
-    def setup_authorization(self):
-        """Set up bearer token and pass on all requests"""
-        valid_token = 'valid-token'
-        self.app.wsgi_app = WSGIApplicationWithEnvironment(
-            self.app.wsgi_app,
-            HTTP_AUTHORIZATION='Bearer {}'.format(valid_token))
-        self._auth_tokens = os.environ.get('DM_SEARCH_API_AUTH_TOKENS')
-        os.environ['DM_SEARCH_API_AUTH_TOKENS'] = valid_token
+        setup_authorization(self.app)
 
     def do_not_provide_access_token(self):
         self.app.wsgi_app = self.app.wsgi_app.app
 
     def teardown(self):
         self.client.delete('/' + self.default_index_name)
-        self.teardown_authorization()
+        teardown_authorization()
 
-    def teardown_authorization(self):
-        if self._auth_tokens is None:
-            del os.environ['DM_SEARCH_API_AUTH_TOKENS']
-        else:
-            os.environ['DM_SEARCH_API_AUTH_TOKENS'] = self._auth_tokens
+
+def setup_authorization(app):
+    """Set up bearer token and pass on all requests"""
+    valid_token = 'valid-token'
+    app.wsgi_app = WSGIApplicationWithEnvironment(
+        app.wsgi_app,
+        HTTP_AUTHORIZATION='Bearer {}'.format(valid_token))
+    os.environ['DM_SEARCH_API_AUTH_TOKENS'] = valid_token
+
+
+def teardown_authorization():
+    del os.environ['DM_SEARCH_API_AUTH_TOKENS']
 
 
 def default_service(**kwargs):

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -46,3 +46,37 @@ class BaseApplicationTest(object):
             del os.environ['DM_SEARCH_API_AUTH_TOKENS']
         else:
             os.environ['DM_SEARCH_API_AUTH_TOKENS'] = self._auth_tokens
+
+
+def default_service(**kwargs):
+    service = {
+        "id": "id",
+        "lot": "LoT",
+        "serviceName": "serviceName",
+        "serviceSummary": "serviceSummary",
+        "serviceBenefits": "serviceBenefits",
+        "serviceFeatures": "serviceFeatures",
+        "serviceTypes": ["serviceTypes"],
+        "supplierName": "Supplier Name",
+        "freeOption": True,
+        "trialOption": True,
+        "minimumContractPeriod": "Month",
+        "supportForThirdParties": True,
+        "selfServiceProvisioning": True,
+        "datacentresEUCode": True,
+        "dataBackupRecovery": True,
+        "dataExtractionRemoval": True,
+        "networksConnected": ["PSN", "PNN"],
+        "apiAccess": True,
+        "openStandardsSupported": True,
+        "openSource": True,
+        "persistentStorage": True,
+        "guaranteedResources": True,
+        "elasticCloud": True
+    }
+
+    service.update(kwargs)
+
+    return {
+        "service": service
+    }

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -3,7 +3,7 @@ from app.main.services import search_service
 from flask import json
 from nose.tools import assert_equal, assert_in
 
-from ..helpers import BaseApplicationTest
+from ..helpers import BaseApplicationTest, default_service
 
 
 class TestSearchIndexes(BaseApplicationTest):
@@ -118,10 +118,9 @@ class TestIndexingDocuments(BaseApplicationTest):
         assert_equal(response.status_code, 200)
 
 
-# TODO write a load of queries into here for the various fields
-class TestSearchQueries(BaseApplicationTest):
+class TestSearchEndpoint(BaseApplicationTest):
     def setup(self):
-        super(TestSearchQueries, self).setup()
+        super(TestSearchEndpoint, self).setup()
         with self.app.app_context():
             services = create_services(10)
             for service in services:
@@ -379,41 +378,10 @@ class TestDeleteById(BaseApplicationTest):
 def create_services(number_of_services):
     services = []
     for i in range(number_of_services):
-        service = default_service()
-        service["service"]["id"] = str(i)
+        service = default_service(id=str(i))
         services.append(service)
 
     return services
-
-
-def default_service():
-    return {
-        "service": {
-            "id": "id",
-            "lot": "LoT",
-            "serviceName": "serviceName",
-            "serviceSummary": "serviceSummary",
-            "serviceBenefits": "serviceBenefits",
-            "serviceFeatures": "serviceFeatures",
-            "serviceTypes": ["serviceTypes"],
-            "supplierName": "Supplier Name",
-            "freeOption": True,
-            "trialOption": True,
-            "minimumContractPeriod": "Month",
-            "supportForThirdParties": True,
-            "selfServiceProvisioning": True,
-            "datacentresEUCode": True,
-            "dataBackupRecovery": True,
-            "dataExtractionRemoval": True,
-            "networksConnected": ["PSN", "PNN"],
-            "apiAccess": True,
-            "openStandardsSupported": True,
-            "openSource": True,
-            "persistentStorage": True,
-            "guaranteedResources": True,
-            "elasticCloud": True
-        }
-    }
 
 
 def get_json_from_response(response):

--- a/tests/app/views/test_search_queries.py
+++ b/tests/app/views/test_search_queries.py
@@ -1,0 +1,183 @@
+from app.main.services import search_service
+from flask import json
+from nose.tools import assert_equal, ok_
+
+from app import create_app
+from ..helpers import setup_authorization, teardown_authorization
+from ..helpers import default_service
+
+
+def test_single_filter_queries():
+    yield check_query, '', 120, {}
+    yield check_query, 'filter_lot=SaaS', 30, {'lot': matches("SaaS")}
+    yield (check_query, 'filter_serviceTypes=Implementation',
+           48, {'serviceTypes': contains('Implementation')})
+    yield check_query, 'filter_minimumContractPeriod=Hour', 40, {}
+    yield check_query, 'filter_openSource=true', 60, {'id': odd}
+
+
+def test_or_filters():
+    yield (check_query, 'filter_lot=SaaS,PaaS',
+           60, {'lot': one_of(['SaaS', 'PaaS'])})
+    yield check_query, 'filter_minimumContractPeriod=Hour,Day', 80, {}
+
+
+def test_and_filters():
+    yield (check_query,
+           'filter_serviceTypes=Planning&filter_serviceTypes=Testing',
+           24, {'serviceTypes': matches(['Planning', 'Testing'])})
+
+    yield (check_query,
+           'filter_serviceTypes=Planning&filter_serviceTypes=Implementation',
+           0, {})
+
+    yield check_query, 'filter_lot=SaaS&filter_lot=PaaS', 0, {}
+
+
+def test_filter_combinations():
+    yield(check_query,
+          'filter_minimumContractPeriod=Hour&filter_openSource=false',
+          20, {'id': even})
+
+    yield(check_query,
+          'filter_minimumContractPeriod=Hour&filter_lot=SaaS',
+          10, {'lot': matches('SaaS')})
+
+    yield(check_query,
+          'q=12&filter_minimumContractPeriod=Hour&filter_lot=SaaS',
+          1, {'lot': matches('SaaS'), 'id': matches('12')})
+
+    yield(check_query,
+          'q=12&filter_minimumContractPeriod=Hour&filter_lot=PaaS', 0, {})
+
+
+# Module setup and teardown
+
+def setup_module():
+    app = create_app('test')
+    test_client = app.test_client()
+
+    setup_authorization(app)
+
+    with app.app_context():
+        services = list(create_services(120))
+        for service in services:
+            test_client.put(
+                '/index-to-create/services/%s' % service["service"]["id"],
+                data=json.dumps(service), content_type='application/json'
+            )
+            search_service.refresh('index-to-create')
+
+
+def teardown_module():
+    app = create_app('test')
+    test_client = app.test_client()
+
+    test_client.delete('/index-to-create')
+    teardown_authorization()
+
+
+# '/search' request helpers
+
+def create_services(number_of_services):
+    for i in range(number_of_services):
+        yield default_service(
+            id=str(i),
+            serviceName="Service {}".format(i),
+            openSource=bool(i % 2),
+            minimumContractPeriod=["Hour", "Day", "Month"][i % 3],
+            lot=["SaaS", "PaaS", "IaaS", "SCS"][i % 4],
+            serviceTypes=[
+                "Implementation",
+                "Ongoing support",
+                "Planning",
+                "Testing",
+                "Training",
+                "Implementation",  # repeated to always get 2 element slice
+            ][i % 5:(i % 5) + 2],
+        )
+
+
+def search_results(query):
+    app = create_app('test')
+    test_client = app.test_client()
+    setup_authorization(app)
+
+    response = test_client.get('/index-to-create/services/search?%s' % query)
+    return json.loads(response.get_data())
+
+
+def search_or_results(query_or_results):
+    if isinstance(query_or_results, dict):
+        return query_or_results
+    else:
+        return search_results(query_or_results)
+
+
+# Result checker functions
+
+def count_for_query(query, expected_count):
+    results = search_or_results(query)
+    assert_equal(
+        results['search']['total'], expected_count,
+        "Unexpected number of results. Expected {}, received {}:\n{}".format(
+            expected_count, results['search']['total'],
+            json.dumps(results, indent=2)
+        )
+    )
+
+    return results
+
+
+def result_fields_check(query, check_fns):
+    results = search_or_results(query)
+    services = results['search']['services']
+    for field in check_fns:
+        ok_(all(check_fns[field](service[field]) for service in services),
+            "Field '{}' check '{}' failed for search results:\n{}".format(
+                field, check_fns[field].__doc__,
+                json.dumps(results, indent=2)))
+
+    return results
+
+
+def check_query(query, expected_result_count, match_fields):
+    results = search_or_results(query)
+    count_for_query(results, expected_result_count)
+    result_fields_check(results, match_fields)
+
+
+# Helpers for 'result_fields_check'
+
+def matches(expected_field):
+    check = lambda result_field: result_field == expected_field
+    check.__doc__ = "Should match '%s'" % expected_field
+    check.__name__ = "matches %s" % expected_field
+
+    return check
+
+
+def contains(expected_field):
+    check = lambda result_field: expected_field in result_field
+    check.__doc__ = "Should contain '%s'" % expected_field
+    check.__name__ = "contains %s" % expected_field
+
+    return check
+
+
+def one_of(expected_fields):
+    check = lambda result_field: result_field in expected_fields
+    check.__doc__ = "Should be in %s" % expected_fields
+    check.__name__ = "one_of %s" % expected_fields
+
+    return check
+
+
+def odd(result_field):
+    "Should be odd."
+    return int(result_field) % 2 == 1
+
+
+def even(result_field):
+    "Should be event."
+    return int(result_field) % 2 == 0


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/93997310

Creates a new module for query tests: app/views/test_search_queries.py.
Module contains module-level setup and teardown functions that populate
the index with a large list of services for query tests.

Since setup and teardown take a long time they're run only once and
all tests use the same index contents, so no modifying/indexing
requests should be made by the module tests.

Query tests are written using nose test generators and a number of
helper functions.

Query results are verified using expected result counts and checks
that verify whether all result field values match a given predicate.

Other helper functions can be added to support checks for different
query types.