### PR TITLE
Keyword search improvements

### DIFF
--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -168,6 +168,7 @@ def multi_match_clause(keywords):
             "query": keywords,
             "fields": TEXT_FIELDS,
             "use_dis_max": True,
+            "default_operator": "and",
         }
     }
 

--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -13,6 +13,7 @@ TEXT_FIELDS = [
     "frameworkName"
 ]
 
+
 FILTER_FIELDS = [
     "lot",
     "serviceTypes",
@@ -106,7 +107,7 @@ class QueryFilter(object):
             "filter_values": self.filter_values,
             "filter_type": self.filter_type,
             "filter_terms": self.terms(),
-            })
+        })
 
 
 def construct_query(query_args, page_size=100):
@@ -163,10 +164,10 @@ def build_keywords_query(query_args):
 
 def multi_match_clause(keywords):
     return {
-        "multi_match": {
+        "query_string": {
             "query": keywords,
             "fields": TEXT_FIELDS,
-            "operator": "and"
+            "use_dis_max": True,
         }
     }
 

--- a/tests/app/services/test_query_builder.py
+++ b/tests/app/services/test_query_builder.py
@@ -35,11 +35,12 @@ def test_should_make_multi_match_query_if_keywords_supplied():
     keywords = "these are my keywords"
     query = construct_query(build_query_params(keywords))
     assert_equal("query" in query, True)
-    assert_equal("multi_match" in query["query"], True)
-    multi_match_clause = query["query"]["multi_match"]
-    assert_equal(multi_match_clause["query"], keywords)
-    assert_equal(multi_match_clause["operator"], "and")
-    assert_equal(multi_match_clause["fields"], [
+    assert_equal("query_string" in query["query"], True)
+    query_string_clause = query["query"]["query_string"]
+    assert_equal(query_string_clause["query"], keywords)
+    assert_equal(query_string_clause["use_dis_max"], True)
+    assert_equal(query_string_clause["default_operator"], "and")
+    assert_equal(query_string_clause["fields"], [
         "id",
         "lot",
         "serviceName",
@@ -89,11 +90,12 @@ def test_should_have_filtered_root_element_and_match_keywords():
         build_query_params(keywords="some keywords",
                            service_types=["my serviceTypes"])
     )
-    assert_equal("multi_match" in query["query"]["filtered"]["query"], True)
-    multi_match_clause = query["query"]["filtered"]["query"]["multi_match"]
-    assert_equal(multi_match_clause["query"], "some keywords")
-    assert_equal(multi_match_clause["operator"], "and")
-    assert_equal(multi_match_clause["fields"], [
+    assert_equal("query_string" in query["query"]["filtered"]["query"], True)
+    query_string_clause = query["query"]["filtered"]["query"]["query_string"]
+    assert_equal(query_string_clause["query"], "some keywords")
+    assert_equal(query_string_clause["use_dis_max"], True)
+    assert_equal(query_string_clause["default_operator"], "and")
+    assert_equal(query_string_clause["fields"], [
         "id",
         "lot",
         "serviceName",

--- a/tests/app/views/test_search_queries.py
+++ b/tests/app/views/test_search_queries.py
@@ -35,24 +35,53 @@ def test_and_filters():
 
 
 def test_filter_combinations():
-    yield(check_query,
-          'filter_minimumContractPeriod=Hour&filter_openSource=false',
-          20, {'id': even})
+    yield (check_query,
+           'filter_minimumContractPeriod=Hour&filter_openSource=false',
+           20, {'id': even})
 
-    yield(check_query,
-          'filter_minimumContractPeriod=Hour&filter_lot=SaaS',
-          10, {'lot': matches('SaaS')})
+    yield (check_query,
+           'filter_minimumContractPeriod=Hour&filter_lot=SaaS',
+           10, {'lot': matches('SaaS')})
 
-    yield(check_query,
-          'q=12&filter_minimumContractPeriod=Hour&filter_lot=SaaS',
-          1, {'lot': matches('SaaS'), 'id': matches('12')})
+    yield (check_query,
+           'q=12&filter_minimumContractPeriod=Hour&filter_lot=SaaS',
+           1, {'lot': matches('SaaS'), 'id': matches('12')})
 
-    yield(check_query,
-          'q=12&filter_minimumContractPeriod=Hour&filter_lot=PaaS', 0, {})
+    yield (check_query,
+           'q=12&filter_minimumContractPeriod=Hour&filter_lot=PaaS', 0, {})
+
+
+def test_basic_keyword_search():
+    yield (check_query,
+           'q=Service',
+           120, {})
+
+
+def test_and_keyword_search():
+    yield (check_query,
+           'q=Service 1',
+           1, {})
+
+
+def test_phrase_keyword_search():
+    yield (check_query,
+           'q="Service 12"',
+           1, {})
+
+
+def test_negated_keyword_search():
+    yield (check_query,
+           'q=Service -12',
+           119, {})
+
+
+def test_or_keyword_search():
+    yield (check_query,
+           'q=Service || 12',
+           120, {})
 
 
 # Module setup and teardown
-
 def setup_module():
     app = create_app('test')
     test_client = app.test_client()


### PR DESCRIPTION
Completes:

https://www.pivotaltracker.com/story/show/94571350

Which is to update keyword search.

This pull request enables Lucene query parsing on the search.

https://www.elastic.co/guide/en/elasticsearch/reference/1.x/query-dsl-query-string-query.html

This means we can:

- Do OR searching (for OR chicken)
- Do phrase searching ("fox eats chicken")
- Do negated searching (fox -farmer)

These 3 search types are the most common "advanced" searches on the digital marketoplace, and as such have tests written to ensure that they work as expected. This is NOT to ensure that lucence parsing works, it's more so that if the query type changes such that these types of search don't work then we know.

By default the search is and AND search - more terms narrows the search.

    "default_operator": "and"

Also it uses the dis_max (https://www.elastic.co/guide/en/elasticsearch/guide/current/_best_fields.html#dis-max-query) sorting option:

    "use_dis_max": True,

This has been demoed to @cath