### PR TITLE
[#94576802] Update Json api format

### DIFF
--- a/app/main/services/response_formatters.py
+++ b/app/main/services/response_formatters.py
@@ -41,9 +41,11 @@ def convert_es_results(results, query_args):
         services.append(result)
 
     return {
-        "query": query_args,
-        "total": total,
-        "took": took,
+        "meta": {
+            "query": query_args,
+            "total": total,
+            "took": took
+        },
         "services": services,
     }
 

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -91,12 +91,14 @@ def keyword_search(index_name, doc_type, query_args):
 
         url_for_search = lambda **kwargs: \
             url_for('.search', index_name=index_name, doc_type=doc_type,
-                    **kwargs)
-
+                    _external=True, **kwargs)
         response = {
-            "search": results,
+            "meta": results['meta'],
+            "services": results['services'],
             "links": generate_pagination_links(
-                query_args, results['total'], page_size, url_for_search)
+                query_args, results['meta']['total'],
+                page_size, url_for_search
+            )
         }
 
         return response, 200

--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -26,7 +26,8 @@ def search(index_name, doc_type):
     result, status_code = keyword_search(index_name, doc_type, request.args)
 
     if status_code == 200:
-        return jsonify(search=result['search'],
+        return jsonify(meta=result['meta'],
+                       services=result['services'],
                        links=result['links']), status_code
     else:
         return jsonify(message=result), status_code

--- a/config.py
+++ b/config.py
@@ -26,6 +26,7 @@ class Test(Config):
 
 class Development(Config):
     DEBUG = True
+    DM_SEARCH_PAGE_SIZE = 5
 
 
 class Live(Config):

--- a/tests/app/services/test_response_formatters.py
+++ b/tests/app/services/test_response_formatters.py
@@ -14,15 +14,15 @@ with open("example_es_responses/search_results.json") as search_results:
 def test_should_build_query_block_in_response():
     res = convert_es_results(SEARCH_RESULTS_JSON,
                              {"q": "keywords", "category": "some catergory"})
-    assert_equal(res["query"]["q"], "keywords")
-    assert_equal(res["query"]["category"], "some catergory")
+    assert_equal(res["meta"]["query"]["q"], "keywords")
+    assert_equal(res["meta"]["query"]["category"], "some catergory")
 
 
 def test_should_build_search_response_from_es_response():
     res = convert_es_results(SEARCH_RESULTS_JSON, {"q": "keywords"})
-    assert_equal(res["query"]["q"], "keywords")
-    assert_equal(res["total"], 628)
-    assert_equal(res["took"], 69)
+    assert_equal(res["meta"]["query"]["q"], "keywords")
+    assert_equal(res["meta"]["total"], 628)
+    assert_equal(res["meta"]["took"], 69)
     assert_equal(len(res["services"]), 10)
 
     assert_equal(res["services"][0]["id"], "5390159512076288")

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -144,7 +144,7 @@ class TestSearchEndpoint(BaseApplicationTest):
                 '/index-to-create/services/search?q=serviceName')
             assert_equal(response.status_code, 200)
             assert_equal(
-                get_json_from_response(response)["search"]["total"], 10)
+                get_json_from_response(response)["meta"]["total"], 10)
 
     def test_should_get_services_up_to_page_size(self):
         with self.app.app_context():
@@ -155,9 +155,9 @@ class TestSearchEndpoint(BaseApplicationTest):
             )
             assert_equal(response.status_code, 200)
             assert_equal(
-                get_json_from_response(response)["search"]["total"], 10)
+                get_json_from_response(response)["meta"]["total"], 10)
             assert_equal(
-                len(get_json_from_response(response)["search"]["services"]), 5)
+                len(get_json_from_response(response)["services"]), 5)
 
     def test_should_get_pagination_links(self):
         with self.app.app_context():
@@ -178,9 +178,9 @@ class TestSearchEndpoint(BaseApplicationTest):
                 '/index-to-create/services/search?q=serviceName&from=5')
             assert_equal(response.status_code, 200)
             assert_equal(
-                get_json_from_response(response)["search"]["total"], 10)
+                get_json_from_response(response)["meta"]["total"], 10)
             assert_equal(
-                len(get_json_from_response(response)["search"]["services"]), 5)
+                len(get_json_from_response(response)["services"]), 5)
 
     def test_should_get_no_services_on_out_of_bounds_from(self):
         with self.app.app_context():
@@ -189,9 +189,9 @@ class TestSearchEndpoint(BaseApplicationTest):
                 '/index-to-create/services/search?q=serviceName&page=3')
             assert_equal(response.status_code, 200)
             assert_equal(
-                get_json_from_response(response)["search"]["total"], 10)
+                get_json_from_response(response)["meta"]["total"], 10)
             assert_equal(
-                len(get_json_from_response(response)["search"]["services"]), 0)
+                len(get_json_from_response(response)["services"]), 0)
 
     def test_should_get_400_response__on_negative_page(self):
         with self.app.app_context():
@@ -226,7 +226,7 @@ class TestSearchEndpoint(BaseApplicationTest):
             assert_equal(response.status_code, 200)
             search_results = get_json_from_response(
                 response
-            )["search"]["services"]
+            )["services"]
             assert_equal(
                 search_results[0]["highlight"]["serviceSummary"][0],
                 highlighted_summary

--- a/tests/app/views/test_search_queries.py
+++ b/tests/app/views/test_search_queries.py
@@ -148,9 +148,9 @@ def search_or_results(query_or_results):
 def count_for_query(query, expected_count):
     results = search_or_results(query)
     assert_equal(
-        results['search']['total'], expected_count,
+        results['meta']['total'], expected_count,
         "Unexpected number of results. Expected {}, received {}:\n{}".format(
-            expected_count, results['search']['total'],
+            expected_count, results['meta']['total'],
             json.dumps(results, indent=2)
         )
     )
@@ -160,7 +160,7 @@ def count_for_query(query, expected_count):
 
 def result_fields_check(query, check_fns):
     results = search_or_results(query)
-    services = results['search']['services']
+    services = results['services']
     for field in check_fns:
         ok_(all(check_fns[field](service[field]) for service in services),
             "Field '{}' check '{}' failed for search results:\n{}".format(


### PR DESCRIPTION
See this story in Pivotal: https://www.pivotaltracker.com/story/show/94576802 - the main aim is to make API response formats consistent across the Data and Search APIs.

There are FOUR related pull-requests to complete this story.  The other three are:
https://github.com/alphagov/digitalmarketplace-api/pull/132
https://github.com/alphagov/digitalmarketplace-utils/pull/39
https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/60

Changes in the search API are to pull out search metadata into the 'meta' element, making the 'services' element at the same level as in the data API's services response.

See these gists for examples of the new API responses:
[Example services data API response](https://gist.github.com/TheDoubleK/0d7cd9363440e700a50d)
[Example suppliers data API response](https://gist.github.com/TheDoubleK/4fde0400e052f20ed2c0)
[Example services search API response](https://gist.github.com/TheDoubleK/8e82782502e611faabcc)