### PR TITLE
Add README link to FeatureFlags docs (in utils)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,8 @@ Alternatively there is an API explorer running on
     [http://localhost:5001/_explorer](http://localhost:5001/_explorer)
 
 Which provides a UI over the API calls.
+
+### Using FeatureFlags
+
+To use feature flags, check out the documentation in (the README of)
+[digitalmarketplace-utils](https://github.com/alphagov/digitalmarketplace-utils#using-featureflags).


### PR DESCRIPTION
Following the same pattern as in [digitalmarkeplace-api](https://github.com/alphagov/digitalmarketplace-api/pull/141).