### PR TITLE
Replace query_string with simple_query_string

### DIFF
--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -163,12 +163,36 @@ def build_keywords_query(query_args):
 
 
 def multi_match_clause(keywords):
+    """Builds a query string supporting basic query syntax.
+
+    Uses "simple_query_string" with a predefined list of supported flags:
+
+        OR          enables the `|` operator
+
+        AND         enables the `+` operator. AND is a default operator, so
+                    adding `+` doesn't affect the results.
+
+        NOT         enables the `-` operator
+
+        WHITESPACE  allows using whitespace escape sequences. `-` operator
+                    doesn't work without the WHITESPACE flag possibly due to
+                    a bug in the current (1.6) version of Elasticsearch.
+
+        PHRASE      enables `"` to group tokens into phrases
+
+        ESCAPE      allows escaping reserved characters with `\`
+
+    (https://www.elastic.co/guide/en/elasticsearch/reference/1.6/query-dsl-simple-query-string-query.html)
+
+    "simple_query_string" doesn't support "use_dis_max" flag.
+
+    """
     return {
-        "query_string": {
+        "simple_query_string": {
             "query": keywords,
             "fields": TEXT_FIELDS,
-            "use_dis_max": True,
             "default_operator": "and",
+            "flags": "OR|AND|NOT|PHRASE|ESCAPE|WHITESPACE"
         }
     }
 

--- a/tests/app/services/test_query_builder.py
+++ b/tests/app/services/test_query_builder.py
@@ -35,10 +35,9 @@ def test_should_make_multi_match_query_if_keywords_supplied():
     keywords = "these are my keywords"
     query = construct_query(build_query_params(keywords))
     assert_equal("query" in query, True)
-    assert_equal("query_string" in query["query"], True)
-    query_string_clause = query["query"]["query_string"]
+    assert_in("simple_query_string", query["query"])
+    query_string_clause = query["query"]["simple_query_string"]
     assert_equal(query_string_clause["query"], keywords)
-    assert_equal(query_string_clause["use_dis_max"], True)
     assert_equal(query_string_clause["default_operator"], "and")
     assert_equal(query_string_clause["fields"], [
         "id",
@@ -89,11 +88,10 @@ def test_should_have_filtered_root_element_and_match_keywords():
     query = construct_query(
         build_query_params(keywords="some keywords",
                            service_types=["my serviceTypes"])
-    )
-    assert_equal("query_string" in query["query"]["filtered"]["query"], True)
-    query_string_clause = query["query"]["filtered"]["query"]["query_string"]
+    )["query"]["filtered"]["query"]
+    assert_in("simple_query_string", query)
+    query_string_clause = query["simple_query_string"]
     assert_equal(query_string_clause["query"], "some keywords")
-    assert_equal(query_string_clause["use_dis_max"], True)
     assert_equal(query_string_clause["default_operator"], "and")
     assert_equal(query_string_clause["fields"], [
         "id",


### PR DESCRIPTION
[#96078646](https://www.pivotaltracker.com/story/show/96078646)

Fixes error responses caused by search requests with the invalid
lucene query syntax by using the simplified query type that only
supports the basic operators and discards invalid parts of the
query instead of throwing an exception.

simple_query_string is configured to support AND, OR, NOT and quote
operators.

Unlike query_string it doesn't seem to support the dis_max query,
which might change the result order. It's hard to say how much this
will affect the results, but using AND as default operator narrows
the results with each added term, so the ranking is less noticeable
than it would be with "OR" queries. It doesn't look like the Grails
app is using the dis_max either.