### PR TITLE
Add datacentreTier field and fix OR filter search

### DIFF
--- a/.ebextensions/indexupdate.config
+++ b/.ebextensions/indexupdate.config
@@ -1,0 +1,4 @@
+container_commands:
+  upgrade:
+    command: "python application.py update_index g-cloud"
+    leader_only: true

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,14 +1,12 @@
 from flask import Flask
 from config import config as configs
 from flask.ext.bootstrap import Bootstrap
+from flask.ext.elasticsearch import FlaskElasticsearch
 from dmutils import init_app, flask_featureflags
-
-from .main import main as main_blueprint
-from .status import status as status_blueprint
-
 
 bootstrap = Bootstrap()
 feature_flags = flask_featureflags.FeatureFlag()
+elasticsearch_client = FlaskElasticsearch()
 
 
 def create_app(config_name):
@@ -20,6 +18,11 @@ def create_app(config_name):
         bootstrap=bootstrap,
         feature_flags=feature_flags
     )
+
+    elasticsearch_client.init_app(application)
+
+    from .main import main as main_blueprint
+    from .status import status as status_blueprint
 
     application.register_blueprint(status_blueprint)
     application.register_blueprint(main_blueprint)

--- a/app/main/services/process_request_json.py
+++ b/app/main/services/process_request_json.py
@@ -1,6 +1,6 @@
 import six
 
-from .query_builder import FILTER_FIELDS, TEXT_FIELDS
+from ...mapping import FILTER_FIELDS, TEXT_FIELDS
 from .conversions import strip_and_lowercase
 
 FILTER_FIELDS_SET = set(FILTER_FIELDS)

--- a/app/main/services/process_request_json.py
+++ b/app/main/services/process_request_json.py
@@ -3,10 +3,11 @@ import six
 from .query_builder import FILTER_FIELDS, TEXT_FIELDS
 from .conversions import strip_and_lowercase
 
+FILTER_FIELDS_SET = set(FILTER_FIELDS)
+TEXT_FIELDS_SET = set(TEXT_FIELDS)
 
-def process_values_for_matching(request_json, key):
-    values = request_json[key]
 
+def process_values_for_matching(values):
     if isinstance(values, list):
         return [strip_and_lowercase(value) for value in values]
     elif isinstance(values, six.string_types):
@@ -16,12 +17,14 @@ def process_values_for_matching(request_json, key):
 
 
 def convert_request_json_into_index_json(request_json):
-    filter_fields = [field for field in request_json if field in FILTER_FIELDS]
+    index_json = {}
 
-    for field in filter_fields:
-        request_json["filter_" + field] = \
-            process_values_for_matching(request_json, field)
-        if field not in TEXT_FIELDS:
-            del request_json[field]
+    for field in request_json:
+        if field in FILTER_FIELDS_SET:
+            index_json["filter_" + field] = process_values_for_matching(
+                request_json[field]
+            )
+        if field in TEXT_FIELDS_SET:
+            index_json[field] = request_json[field]
 
-    return request_json
+    return index_json

--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -23,6 +23,7 @@ FILTER_FIELDS = [
     "supportForThirdParties",
     "selfServiceProvisioning",
     "datacentresEUCode",
+    "datacentreTier",
     "dataBackupRecovery",
     "dataExtractionRemoval",
     "networksConnected",

--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -1,39 +1,5 @@
 from .conversions import strip_and_lowercase
-
-# These two arrays should be part of a mapping definition
-TEXT_FIELDS = [
-    "id",
-    "lot",
-    "serviceName",
-    "serviceSummary",
-    "serviceFeatures",
-    "serviceBenefits",
-    "serviceTypes",
-    "supplierName",
-    "frameworkName"
-]
-
-
-FILTER_FIELDS = [
-    "lot",
-    "serviceTypes",
-    "freeOption",
-    "trialOption",
-    "minimumContractPeriod",
-    "supportForThirdParties",
-    "selfServiceProvisioning",
-    "datacentresEUCode",
-    "datacentreTier",
-    "dataBackupRecovery",
-    "dataExtractionRemoval",
-    "networksConnected",
-    "apiAccess",
-    "openStandardsSupported",
-    "openSource",
-    "persistentStorage",
-    "guaranteedResources",
-    "elasticCloud"
-]
+from ...mapping import TEXT_FIELDS, FILTER_FIELDS
 
 
 def construct_query(query_args, page_size=100):

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -23,6 +23,10 @@ def create_index(index_name):
     except TransportError as e:
         if u'IndexAlreadyExistsException' in _get_an_error_message(e):
             return put_index_mapping(index_name)
+        current_app.logger.error(
+            "Failed to create the index %s: %s",
+            index, _get_an_error_message(e)
+        )
         return _get_an_error_message(e), e.status_code
 
 
@@ -35,6 +39,10 @@ def put_index_mapping(index_name):
         )
         return "acknowledged", 200
     except TransportError as e:
+        current_app.logger.error(
+            "Failed to update the index mapping for %s: %s",
+            index, _get_an_error_message(e)
+        )
         return _get_an_error_message(e), e.status_code
 
 
@@ -71,6 +79,10 @@ def index(index_name, doc_type, document, document_id):
             body=document)
         return "acknowledged", 200
     except TransportError as e:
+        current_app.logger.error(
+            "Failed to index the document %s: %s",
+            document_id, _get_an_error_message(e)
+        )
         return _get_an_error_message(e), e.status_code
 
 

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -1,14 +1,11 @@
-import os
+from flask import current_app, url_for
+from elasticsearch import TransportError
 
-from elasticsearch import Elasticsearch, TransportError
+from ... import elasticsearch_client as es
 from app.mapping import SERVICES_MAPPING
 from app.main.services.response_formatters import \
     convert_es_status, convert_es_results, generate_pagination_links
 from app.main.services.query_builder import construct_query
-from flask import current_app, url_for
-
-es_url = os.getenv('DM_ELASTICSEARCH_URL')
-es = Elasticsearch(es_url)
 
 
 def refresh(index_name):

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -24,6 +24,20 @@ def create_index(index_name):
         es.indices.create(index=index_name, body=SERVICES_MAPPING)
         return "acknowledged", 200
     except TransportError as e:
+        if u'IndexAlreadyExistsException' in _get_an_error_message(e):
+            return put_index_mapping(index_name)
+        return _get_an_error_message(e), e.status_code
+
+
+def put_index_mapping(index_name):
+    try:
+        es.indices.put_mapping(
+            index=index_name,
+            doc_type="services",
+            body=SERVICES_MAPPING["mappings"]["services"]
+        )
+        return "acknowledged", 200
+    except TransportError as e:
         return _get_an_error_message(e), e.status_code
 
 

--- a/app/mapping.py
+++ b/app/mapping.py
@@ -3,3 +3,15 @@ from flask import json
 
 with open("mappings/services.json") as services:
     SERVICES_MAPPING = json.load(services)
+
+FILTER_FIELDS = sorted(
+    field.replace('filter_', '')
+    for field in SERVICES_MAPPING['mappings']['services']['properties'].keys()
+    if field.startswith('filter_')
+)
+
+TEXT_FIELDS = sorted(
+    field
+    for field in SERVICES_MAPPING['mappings']['services']['properties'].keys()
+    if not field.startswith('filter_')
+)

--- a/application.py
+++ b/application.py
@@ -8,5 +8,15 @@ application = create_app(os.getenv('DM_ENVIRONMENT') or 'development')
 manager = Manager(application)
 manager.add_command("runserver", Server(port=5001))
 
+
+@manager.command
+def update_index(index_name):
+    from app.main.services.search_service import create_index
+    with application.app_context():
+        message, status = create_index(index_name)
+    assert status == 200, message
+    application.logger.info("Created index %s", index_name)
+
+
 if __name__ == '__main__':
     manager.run()

--- a/config.py
+++ b/config.py
@@ -11,6 +11,9 @@ class Config:
     )
     AUTH_REQUIRED = True
     ALLOW_EXPLORER = True
+
+    ELASTICSEARCH_HOST = os.getenv('DM_ELASTICSEARCH_URL', 'localhost:9200')
+
     DM_SEARCH_PAGE_SIZE = 100
     # Logging
     DM_LOG_LEVEL = 'DEBUG'

--- a/mappings/services.json
+++ b/mappings/services.json
@@ -60,6 +60,10 @@
           "type": "boolean",
           "index": "not_analyzed"
         },
+        "filter_datacentreTier": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
         "filter_dataBackupRecovery": {
           "type": "boolean",
           "index": "not_analyzed"

--- a/mappings/services.json
+++ b/mappings/services.json
@@ -32,6 +32,10 @@
         "serviceTypes": {
           "type": "string"
         },
+        "filter_lot": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
         "filter_serviceTypes": {
           "type": "string",
           "index": "not_analyzed"

--- a/mappings/services.json
+++ b/mappings/services.json
@@ -1,6 +1,7 @@
 {
   "mappings": {
     "services": {
+      "dynamic": "strict",
       "properties": {
         "id": {
           "type": "string",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ git+https://github.com/alphagov/digitalmarketplace-utils.git@0.21.0#egg=digitalm
 
 # Elasticsearch 1.0
 elasticsearch>=1.0.0,<2.0.0
+Flask-Elasticsearch==0.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [pep8]
 exclude = ./venv
+max-line-length = 120

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -65,6 +65,7 @@ def default_service(**kwargs):
         "dataBackupRecovery": True,
         "dataExtractionRemoval": True,
         "networksConnected": ["PSN", "PNN"],
+        "datacentreTier": "tia-942 tier 1",
         "apiAccess": True,
         "openStandardsSupported": True,
         "openSource": True,

--- a/tests/app/services/test_process_request_json.py
+++ b/tests/app/services/test_process_request_json.py
@@ -3,40 +3,48 @@ from app.main.services.process_request_json import \
 from nose.tools import assert_equal
 
 
-def test_should_make_filter_match_string_fields():
+def test_should_add_filter_fields_to_index_json():
     request = {
-        "lot": "SaaS"
+        "lot": "SaaS",
+        "freeOption": True,
     }
 
     result = convert_request_json_into_index_json(request)
-    assert_equal(result["lot"], "SaaS")
-    assert_equal(result["filter_lot"], "saas")
+    assert_equal(result, {
+        "lot": "SaaS",
+        "filter_lot": "saas",
+        "filter_freeOption": True,
+    })
 
 
 def test_should_make__match_array_fields():
     request = {
         "lot": "SaaS",
-        "serviceTypes": ["One", "Two", "Three"]
+        "serviceTypes": ["One", "Two", "Three"],
+        "networksConnected": ["Internet", "PSN"],
     }
 
     result = convert_request_json_into_index_json(request)
-    assert_equal(result["lot"], "SaaS")
-    assert_equal(result["filter_lot"], "saas")
-    assert_equal(result["serviceTypes"], ["One", "Two", "Three"])
-    assert_equal(result["filter_serviceTypes"], ["one", "two", "three"])
+    assert_equal(result, {
+        "lot": "SaaS",
+        "filter_lot": "saas",
+        "serviceTypes": ["One", "Two", "Three"],
+        "filter_serviceTypes": ["one", "two", "three"],
+        "filter_networksConnected": ["internet", "psn"],
+    })
 
 
-def test_should_ignore_non_filter_fields():
+def test_should_ignore_non_filter_and_non_text_fields():
     request = {
         "lot": "SaaS",
         "ignore": "Unchanged",
     }
 
     result = convert_request_json_into_index_json(request)
-    assert_equal(result["lot"], "SaaS")
-    assert_equal(result["filter_lot"], "saas")
-    assert_equal(result["ignore"], "Unchanged")
-    assert_equal("filter_ignore" in result, False)
+    assert_equal(result, {
+        "lot": "SaaS",
+        "filter_lot": "saas",
+    })
 
 
 def test_should_remove_raw_filter_fields_that_are_non_text():

--- a/tests/app/services/test_query_builder.py
+++ b/tests/app/services/test_query_builder.py
@@ -47,15 +47,15 @@ def test_should_make_multi_match_query_if_keywords_supplied():
     assert_equal(query_string_clause["query"], keywords)
     assert_equal(query_string_clause["default_operator"], "and")
     assert_equal(query_string_clause["fields"], [
+        "frameworkName",
         "id",
         "lot",
+        "serviceBenefits",
+        "serviceFeatures",
         "serviceName",
         "serviceSummary",
-        "serviceFeatures",
-        "serviceBenefits",
         "serviceTypes",
         "supplierName",
-        "frameworkName",
     ])
 
 
@@ -101,15 +101,15 @@ def test_should_have_filtered_root_element_and_match_keywords():
     assert_equal(query_string_clause["query"], "some keywords")
     assert_equal(query_string_clause["default_operator"], "and")
     assert_equal(query_string_clause["fields"], [
+        "frameworkName",
         "id",
         "lot",
+        "serviceBenefits",
+        "serviceFeatures",
         "serviceName",
         "serviceSummary",
-        "serviceFeatures",
-        "serviceBenefits",
         "serviceTypes",
         "supplierName",
-        "frameworkName",
     ])
 
 

--- a/tests/app/services/test_query_builder.py
+++ b/tests/app/services/test_query_builder.py
@@ -1,6 +1,13 @@
-from nose.tools import assert_equal, assert_in, assert_not_in, assert_false
-from app.main.services.query_builder import construct_query, \
-    is_filtered
+from nose.tools import (
+    assert_equal, assert_in, assert_not_in,
+    assert_false, assert_true
+)
+from app.main.services.query_builder import construct_query, is_filtered
+from app.main.services.query_builder import (
+    field_is_or_filter, field_filters,
+    or_field_filters, and_field_filters,
+    filter_clause
+)
 from werkzeug.datastructures import MultiDict
 
 
@@ -231,3 +238,118 @@ def build_query_params(keywords=None, service_types=None, lot=None, page=None):
     if page:
         query_params["page"] = page
     return query_params
+
+
+class TestFieldFilters(object):
+    def test_field_is_or_filter(self):
+        assert_true(field_is_or_filter(['a,b']))
+
+    def test_field_is_or_filter_no_comma(self):
+        assert_false(field_is_or_filter(['a']))
+
+    def test_field_is_or_filter_multiple_values_no_comma(self):
+        assert_false(field_is_or_filter(['a', 'b']))
+
+    def test_field_is_or_filter_multiple_values(self):
+        assert_false(field_is_or_filter(['a,b', 'b,c']))
+
+    def test_or_field_filters(self):
+        assert_equal(
+            or_field_filters('filterName', ['Aa bb', 'Bb cc']),
+            [{"terms": {"filterName": ['aabb', 'bbcc'], "execution": "bool"}}]
+        )
+
+    def test_or_field_filters_single_value(self):
+        assert_equal(
+            or_field_filters('filterName', ['Aa bb']),
+            [{"terms": {"filterName": ['aabb'], "execution": "bool"}}]
+        )
+
+    def test_and_field_filters(self):
+        assert_equal(
+            and_field_filters('filterName', ['Aa bb', 'Bb cc']),
+            [
+                {"term": {"filterName": 'aabb'}},
+                {"term": {"filterName": 'bbcc'}}
+            ]
+        )
+
+    def test_and_field_filters_single_value(self):
+        assert_equal(
+            and_field_filters('filterName', ['Aa bb']),
+            [{"term": {"filterName": 'aabb'}}]
+        )
+
+    def test_field_filters_single_value(self):
+        assert_equal(
+            field_filters('filterName', ['Aa Bb']),
+            [{"term": {"filterName": 'aabb'}}]
+        )
+
+    def test_field_filters_multiple_and_values(self):
+        assert_equal(
+            field_filters('filterName', ['Aa bb', 'Bb,Cc']),
+            [
+                {"term": {"filterName": 'aabb'}},
+                {"term": {"filterName": 'bbcc'}}
+            ]
+        )
+
+    def test_field_filters_or_value(self):
+        assert_equal(
+            field_filters('filterName', ['Aa,Bb']),
+            [{"terms": {"filterName": ['aa', 'bb'], "execution": "bool"}}]
+        )
+
+
+class TestFilterClause(object):
+    def test_filter_ignores_non_filter_query_args(self):
+        assert_equal(
+            filter_clause(
+                MultiDict({'fieldName': ['Aa bb'], 'lot': ['saas']})
+            ),
+            {'bool': {'must': []}}
+        )
+
+    def test_single_and_field(self):
+        assert_equal(
+            filter_clause(MultiDict(
+                {'filter_fieldName': ['Aa bb'], 'lot': 'saas'}
+            )),
+            {'bool': {
+                'must': [
+                    {"term": {"filter_fieldName": 'aabb'}},
+                ]
+            }}
+        )
+
+    def test_single_or_field(self):
+        assert_equal(
+            filter_clause(MultiDict({'filter_fieldName': ['Aa,Bb']})),
+            {'bool': {
+                'must': [
+                    {"terms": {"filter_fieldName": ['aa', 'bb'], "execution": "bool"}},
+                ]
+            }}
+        )
+
+    def test_or_and_combination(self):
+        bool_filter = filter_clause(MultiDict({
+            'filter_andFieldName': ['Aa', 'bb'],
+            'filter_orFieldName': ['Aa,Bb']
+        }))
+
+        assert_in(
+            {"terms": {"filter_orFieldName": ['aa', 'bb'], "execution": "bool"}},
+            bool_filter['bool']['must']
+        )
+
+        assert_in(
+            {"term": {"filter_andFieldName": 'aa'}},
+            bool_filter['bool']['must']
+        )
+
+        assert_in(
+            {"term": {"filter_andFieldName": 'bb'}},
+            bool_filter['bool']['must']
+        )

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -75,7 +75,8 @@ class TestIndexingDocuments(BaseApplicationTest):
 
         assert_equal(response.status_code, 200)
 
-        search_service.refresh('index-to-create')
+        with self.app.app_context():
+            search_service.refresh('index-to-create')
         response = self.client.get('/index-to-create/status')
         assert_equal(response.status_code, 200)
         assert_equal(
@@ -258,7 +259,8 @@ class TestFetchById(BaseApplicationTest):
             content_type='application/json'
         )
 
-        search_service.refresh('index-to-create')
+        with self.app.app_context():
+            search_service.refresh('index-to-create')
 
         response = self.client.get(
             '/index-to-create/services/' + str(service["service"]["id"]))
@@ -316,7 +318,8 @@ class TestFetchById(BaseApplicationTest):
             content_type='application/json'
         )
 
-        search_service.refresh("index-to-create")
+        with self.app.app_context():
+            search_service.refresh('index-to-create')
         response = self.client.get(
             '/index-to-create/services/' + str(service["service"]["id"]))
 
@@ -358,7 +361,8 @@ class TestDeleteById(BaseApplicationTest):
             content_type='application/json'
         )
 
-        search_service.refresh('index-to-create')
+        with self.app.app_context():
+            search_service.refresh('index-to-create')
         response = self.client.delete(
             '/index-to-create/services/' + str(service["service"]["id"]))
 

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -295,9 +295,7 @@ class TestFetchById(BaseApplicationTest):
             original = service["service"][key[1]]
             indexed = data['services']["_source"][key[0]]
             if key[0].startswith("filter"):
-                original = process_values_for_matching(
-                    service["service"],
-                    key[1])
+                original = process_values_for_matching(service["service"][key[1]])
             assert_equal(original, indexed)
 
     def test_service_should_have_all_exact_match_fields(self):
@@ -338,7 +336,7 @@ class TestFetchById(BaseApplicationTest):
         for key in cases:
             assert_equal(
                 data['services']["_source"]["filter_" + key],
-                process_values_for_matching(service["service"], key))
+                process_values_for_matching(service["service"][key]))
 
 
 class TestDeleteById(BaseApplicationTest):

--- a/tests/app/views/test_search_queries.py
+++ b/tests/app/views/test_search_queries.py
@@ -20,6 +20,13 @@ def test_or_filters():
     yield (check_query, 'filter_lot=SaaS,PaaS',
            60, {'lot': one_of(['SaaS', 'PaaS'])})
     yield check_query, 'filter_minimumContractPeriod=Hour,Day', 80, {}
+    yield (check_query, 'filter_datacentreTier=tia-942 tier 1,tia-942 tier 2',
+           120, {})
+    yield (check_query, 'filter_datacentreTier=tia-942 tier 3,tia-942 tier 2',
+           0, {})
+    yield (check_query,
+           'filter_minimumContractPeriod=Hour,Day&filter_datacentreTier=tia-942 tier 3,tia-942 tier 2',
+           0, {})
 
 
 def test_and_filters():
@@ -37,6 +44,14 @@ def test_and_filters():
 def test_filter_combinations():
     yield (check_query,
            'filter_minimumContractPeriod=Hour&filter_openSource=false',
+           20, {'id': even})
+
+    yield (check_query,
+           'filter_minimumContractPeriod=Hour,Day&filter_openSource=false',
+           40, {'id': even})
+
+    yield (check_query,
+           'filter_minimumContractPeriod=Hour,Day&filter_openSource=false&filter_lot=SaaS',
            20, {'id': even})
 
     yield (check_query,

--- a/tests/app/views/test_status.py
+++ b/tests/app/views/test_status.py
@@ -14,10 +14,10 @@ class TestStatus(BaseApplicationTest):
 
             assert_equal(response.status_code, 200)
 
-    @mock.patch('app.main.services.search_service.es.indices.status')
-    def test_status_when_elasticsearch_is_down(self, status):
+    @mock.patch('app.main.services.search_service.es.indices')
+    def test_status_when_elasticsearch_is_down(self, indices):
         with self.app.app_context():
-            status.side_effect = TransportError(500, "BARR", "FOO")
+            indices.status.side_effect = TransportError(500, "BARR", "FOO")
             response = self.client.get('/_status')
 
             assert_equal(response.status_code, 500)


### PR DESCRIPTION
### 	Add datacentreTier to the list of filter fields

Datacentre Tier is one of the filters shown in the buyer-frontend,
so it should be indexed and accepted as a filter field.

Right now adding a field requires adding it to the list of fields
and to the mapping attached to the index. The existing index mapping
is not affected by the mapping.json change.

### 	Add missing filter_lot to the Elasticsearch mappings

"lot" is both a text and a filter field, so it should have both
definitions in the index mapping. Right now, "filter_lot" is created
dynamically by Elasticsearch when the field is first encountered on
document insert.

### 	Rewrite query_builder to fix multiple-OR-filters error

Previous version of the filter builder would group OR filter values
inside a single `bool` `"should"` list, which means a document only
needed to match any of the combined list of values, not at least one
value per OR filter field.

Instead, OR filters now return a single "terms" filter that checks if
the field matches any of the given values. All field filters are then
joined in a single `bool` `"must"` list, which makes sure that all of
the field filters are matched at the same time.

This simplifies the code a bit since there's no need to group filters
between `"must"` and `"should"` lists anymore, so we can get rid of the
QueryFilter class.

### 	Drop any unknown request fields when converting into index document

Previously, convert_request_json_into_index_json relied on the request
being sent through the dmutils.apiclient, which dropped any fields that
aren't supposed to be indexed. This means that dmutils contains a copy
of the filter and text fields lists.

Instead, new converting functions only keeps text and filter fields from
the request, so it can accept any service document for indexing.

### Generate TEXT_ and FILTER_ fields from the index mapping

Makes sure field lists are always in-sync with the index mapping
definition and there's only one place that needs changing to
add or modify an index field.

### Use flask-elasticsearch extension to create ES client

Replaces global elasticsearch client from search_service with
a client created by a flask extension. Similar to how we handle other
global clients for API and DB connections.

### Add a manager command to create/update ES index and mapping
Command will be run by Elasticbeanstalk during application deployment
similar to the way DB migrations are run by the Data API.

### Disallow implicit field creation in the services mapping
By default elasticsearch will try to guess the types of fields that
aren't listed in the index mapping and will add them to the mapping.

Setting dynamic to strict makes ES insted throw an error when trying
to index a document with unknown fields. This makes sure that our
mapping is up-to-date and the indexed documents are matching it.