### PR TITLE
Escape HTML in "highlight" search results text

### DIFF
--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -138,10 +138,11 @@ def construct_query(query_args, page_size=100):
 
 
 def highlight_clause():
-    highlights = dict({
+    highlights = {
+        "encoder": "html",
         "pre_tags": ["<em class='search-result-highlighted-text'>"],
         "post_tags": ["</em>"]
-    })
+    }
     highlights["fields"] = {}
 
     for field in TEXT_FIELDS:

--- a/tests/app/services/test_query_builder.py
+++ b/tests/app/services/test_query_builder.py
@@ -193,6 +193,14 @@ def test_should_have_highlight_block_on_filtered_search():
     assert_equal("highlight" in query, True)
 
 
+def test_highlight_block_sets_encoder_to_html():
+    query = construct_query(
+        build_query_params(keywords="some keywords",
+                           service_types=["some serviceTypes"]))
+
+    assert_equal(query["highlight"]["encoder"], "html")
+
+
 def test_highlight_block_contains_correct_fields():
     query = construct_query(
         build_query_params(keywords="some keywords",


### PR DESCRIPTION
[#98468022](https://www.pivotaltracker.com/story/show/98468022)

Hightlighted fragments are wrapped in html tags, which makes it hard
for the buyer-frontend to escape any html entities in the original
service field. Setting elasticsearch "highlight" `encoder` to `html`
makes it encode HTML in the original field data before adding
highlighting tags. This way buyer-frontend can treat highlighted
strings as safe without any additional escaping.

(https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html#_encoder)