### PR TITLE
Added no dependecy elb status page check

### DIFF
--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,4 +1,4 @@
-from flask import jsonify, current_app
+from flask import jsonify, current_app, request
 
 from . import status
 from ..main.services.search_service import status_for_all_indexes
@@ -7,6 +7,11 @@ from dmutils.status import get_flags
 
 @status.route('/_status')
 def status():
+
+    if 'ignore-dependencies' in request.args:
+        return jsonify(
+            status="ok",
+        ), 200
 
     result, status_code = status_for_all_indexes()
     version = current_app.config['VERSION']

--- a/tests/app/views/test_status.py
+++ b/tests/app/views/test_status.py
@@ -14,6 +14,10 @@ class TestStatus(BaseApplicationTest):
 
             assert_equal(response.status_code, 200)
 
+    def test_should_return_200_from_elb_status_check(self):
+        status_response = self.client.get('/_status?ignore-dependencies')
+        assert_equal(200, status_response.status_code)
+
     @mock.patch('app.main.services.search_service.es.indices')
     def test_status_when_elasticsearch_is_down(self, indices):
         with self.app.app_context():


### PR DESCRIPTION
Checks app is up without hitting depencies if passed a ?ignore-dependencies query param. For use in ELB load balancers