### PR TITLE
Use custom access log for CloudWatch

### DIFF
--- a/.ebextensions/apache_log.config
+++ b/.ebextensions/apache_log.config
@@ -1,0 +1,8 @@
+files:
+  "/etc/httpd/conf.d/custom_log.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      LogFormat "apache-access search-api \"%{DM-Request-ID}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" cloudwatchlogs
+      CustomLog logs/cwl_access_log cloudwatchlogs

--- a/.ebextensions/cwl-logs-apache-access.config
+++ b/.ebextensions/cwl-logs-apache-access.config
@@ -28,15 +28,15 @@
 Mappings:
   CWLogs:
     AccessLogs:
-      LogFile: "/var/log/httpd/access_log"
+      LogFile: "/var/log/httpd/cwl_access_log"
       TimestampFormat: "%d/%b/%Y:%H:%M:%S %z"
       LogGroupName: {"Fn::GetOptionSetting": {"OptionName": "LogGroupName"}}
       ApplicationName: {"Fn::GetOptionSetting": {"OptionName": "ApplicationName"}}
     FilterPatterns:
-      Http4xxMetricFilter: "[..., status=4*, size, referer, agent]"  
-      HttpNon4xxMetricFilter: "[..., status!=4*, size, referer, agent]"
-      Http5xxMetricFilter: "[..., status=5*, size, referer, agent]"  
-      HttpNon5xxMetricFilter: "[..., status!=5*, size, referer, agent]"  
+      Http4xxMetricFilter: "[type=apache-access, app=search-api, ..., status=4*, size, referer, agent]"  
+      HttpNon4xxMetricFilter: "[type=apache-access, app=search-api, ..., status!=4*, size, referer, agent]"
+      Http5xxMetricFilter: "[type=apache-access, app=search-api, ..., status=5*, size, referer, agent]"  
+      HttpNon5xxMetricFilter: "[type=apache-access, app=search-api, ..., status!=5*, size, referer, agent]"  
 
 
 Outputs:
@@ -128,7 +128,15 @@ Resources :
     Type : "AWS::CloudWatch::Alarm"
     DependsOn : AWSEBCWLHttpNon5xxMetricFilter
     Properties :
-      AlarmDescription: "Application is returning too many 5xx responses (count too high)."
+      AlarmDescription:
+        "Fn::Join":
+          - ""
+          -
+            - "The search API is returning too many 5xx responses.\n"
+            - "Stage and environment: "
+            - {"Fn::FindInMap": ["CWLogs", "AccessLogs", "LogGroupName"]}
+            - "\n"
+            - "Manual link: https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#5xx-error-rate"
       MetricName: CWLHttp5xx
       Namespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
       Statistic: Sum
@@ -149,7 +157,15 @@ Resources :
     Type : "AWS::CloudWatch::Alarm"
     DependsOn : AWSEBCWLHttpNon4xxMetricFilter
     Properties :
-      AlarmDescription: "Application is returning too many 4xx responses (percentage too high)."
+      AlarmDescription:
+        "Fn::Join":
+          - ""
+          -
+            - "The search API is returning too high a proportion of 4xx responses.\n"
+            - "Stage and environment: "
+            - {"Fn::FindInMap": ["CWLogs", "AccessLogs", "LogGroupName"]}
+            - "\n"
+            - "Manual link: https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#4xx-error-rate"
       MetricName: CWLHttp4xx
       Namespace: {"Fn::Join":["/", ["ElasticBeanstalk", {"Ref":"AWSEBEnvironmentName"}]]}
       Statistic: Average


### PR DESCRIPTION
Create a new Apache access log with type and application information in
so that we can distinguish where a log message has come from. The
CloudWatch metric filters are applied to all messages in a log group and
seeing as we put all our log streams in the same group so that we can
easily search over them this means our alarms do not work properly.

This change also updates the alarm descriptions to be a bit more
helpful. They now say which application and environment the alarm came
from and link to the manual explaining what should be done.

See:
alphagov/digitalmarketplace-api#174 
alphagov/digitalmarketplace-api#175
alphagov/digitalmarketplace-api#176
alphagov/digitalmarketplace-api#177