### PR TITLE
[#99425224] Add rough word limit on es highlight excerpts

### DIFF
--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -38,7 +38,12 @@ def highlight_clause():
     highlights["fields"] = {}
 
     for field in TEXT_FIELDS:
-        highlights["fields"][field] = {}
+        # 400 characters is generally >= 50 words
+        highlights["fields"][field] = {
+            "number_of_fragments": 1,
+            "fragment_size": 400,
+            "no_match_size": 400
+        }
 
     return highlights
 

--- a/tests/app/services/test_query_builder.py
+++ b/tests/app/services/test_query_builder.py
@@ -234,6 +234,16 @@ def test_highlight_block_contains_correct_fields():
             example
 
 
+def test_highlight_block_character_length_for_service_summary():
+    query = construct_query(
+        build_query_params(keywords="some keywords",
+                           service_types=["some serviceTypes"]))
+
+    assert_equal("highlight" in query, True)
+    assert_equal(query["highlight"]["fields"]["serviceSummary"]["no_match_size"], 400)
+    assert_equal(query["highlight"]["fields"]["serviceSummary"]["fragment_size"], 400)
+
+
 def build_query_params(keywords=None, service_types=None, lot=None, page=None):
     query_params = MultiDict()
     if keywords:


### PR DESCRIPTION
**This fixes a problem whereby the entire service summary for G5 services (some of which have really long summaries) would be returned in the search results if no search terms were specified.**

***

Highlight excerpts for all service fields returned from elasticsearch now 400 character limit. This is enforced whether or not a search term has been found.
If no search term is found, up to the first 400 characters of the field will be used as the basis for the `highlight` snippet.

elasticsearch tries not to break in the middle of a word.  From the documentation: 
> The actual length may be shorter than specified as it tries to break on a word boundary.

Trailing punctuation is also removed.
Roughly approximates our 50-word limit on service summaries for G6+ services.

More information about highlighted fragments can be found [here](https://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-highlighting.html#_highlighted_fragments).

[>> Story on Pivotal](https://www.pivotaltracker.com/story/show/99425224)

***

#### G5 Service with really long description before character limit
![screen shot 2015-08-04 at 15 24 42](https://cloud.githubusercontent.com/assets/2454380/9063222/5b75f856-3abe-11e5-8372-25aa611a57ae.png)


#### G5 Service with really long description after character limit
![screen shot 2015-08-04 at 15 25 11](https://cloud.githubusercontent.com/assets/2454380/9063225/5fca281e-3abe-11e5-8264-aad66a8da9fe.png)

*** 

#### Notes: 
Discovered what appears to be a bug.
The character limit for a highlight excerpt (when a match has been found) is only respected if the character limit is less than ~2/3 of the original data.
For example, if a matched word is found in a 600-character service summary and our `fragment_size` limit is set to `400`, the entire summary will be returned as a highlight fragment.
A 610-character service summary would be truncated as expected.
Using the fast vector highlighter seems to fix the problem, but since it's not really an issue for us, I've not changed the default highlighter.