### PR TITLE
Use <mark> element for highlighting search results

### DIFF
--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -32,8 +32,8 @@ def construct_query(query_args, page_size=100):
 def highlight_clause():
     highlights = {
         "encoder": "html",
-        "pre_tags": ["<em class='search-result-highlighted-text'>"],
-        "post_tags": ["</em>"]
+        "pre_tags": ["<mark class='search-result-highlighted-text'>"],
+        "post_tags": ["</mark>"]
     }
     highlights["fields"] = {}
 

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -237,7 +237,7 @@ class TestSearchEndpoint(BaseApplicationTest):
             serviceSummary="Accessing, storing and retaining email"
         )
         highlighted_summary = \
-            "Accessing, <em class='search-result-highlighted-text'>storing</em> and retaining email"
+            "Accessing, <mark class='search-result-highlighted-text'>storing</mark> and retaining email"
 
         response = self._put_into_and_get_back_from_elasticsearch(
             service=service,
@@ -265,8 +265,8 @@ class TestSearchEndpoint(BaseApplicationTest):
         search_results = get_json_from_response(response)["services"]
         assert_equal(
             search_results[0]["highlight"]["serviceSummary"][0],
-            "accessing, <em class='search-result-highlighted-text'>" +
-            "storing</em> &lt;h1&gt;and retaining&lt;&#x2F;h1&gt; email"
+            "accessing, <mark class='search-result-highlighted-text'>" +
+            "storing</mark> &lt;h1&gt;and retaining&lt;&#x2F;h1&gt; email"
         )
 
     def test_highlight_service_summary_limited_if_search_string_matches(self):


### PR DESCRIPTION
This is the semantically appropriate element:
> The HTML Mark Element (`<mark>`) represents highlighted text, i.e., a run of text marked for reference purpose, due to its relevance in a particular context. For example it can be used in a page showing search results to highlight every instance of the searched-for word.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark

It is also the element used on GOV.UK search results:
https://github.com/alphagov/frontend/blob/6711d367ec026c74c45b87e8ca8ceeda52396576/app/assets/stylesheets/views/_search.scss#L137