### PR TITLE
Use postings highlighter for the serviceSummary field

### DIFF
--- a/mappings/services.json
+++ b/mappings/services.json
@@ -19,6 +19,7 @@
           "type": "string"
         },
         "serviceSummary": {
+          "index_options" : "offsets",
           "type": "string"
         },
         "serviceBenefits": {

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -133,6 +133,7 @@ class TestIndexingDocuments(BaseApplicationTest):
 class TestSearchEndpoint(BaseApplicationTest):
     def setup(self):
         super(TestSearchEndpoint, self).setup()
+        self.client.put('/index-to-create')
         with self.app.app_context():
             services = create_services(10)
             for service in services:
@@ -283,7 +284,7 @@ class TestSearchEndpoint(BaseApplicationTest):
         search_results = get_json_from_response(response)["services"]
         assert_equal(
             search_results[0]["highlight"]["serviceSummary"][0],
-            "Oh <script>alert(\"Yo\");</script>"
+            "Oh &lt;script&gt;alert(&quot;Yo&quot;);&lt;&#x2F;script&gt;"
         )
 
     def test_highlight_service_summary_limited_if_search_string_matches(self):

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -269,6 +269,23 @@ class TestSearchEndpoint(BaseApplicationTest):
             "storing</mark> &lt;h1&gt;and retaining&lt;&#x2F;h1&gt; email"
         )
 
+    def test_unhighlighted_result_should_escape_html(self):
+        service = default_service(
+            serviceSummary='Oh <script>alert("Yo");</script>',
+            lot='oY'
+        )
+
+        response = self._put_into_and_get_back_from_elasticsearch(
+            service=service,
+            query_string='q=oY'
+        )
+        assert_equal(response.status_code, 200)
+        search_results = get_json_from_response(response)["services"]
+        assert_equal(
+            search_results[0]["highlight"]["serviceSummary"][0],
+            "Oh <script>alert(\"Yo\");</script>"
+        )
+
     def test_highlight_service_summary_limited_if_search_string_matches(self):
 
         # 200 words, 1000 characters

--- a/tests/app/views/test_search_queries.py
+++ b/tests/app/views/test_search_queries.py
@@ -110,8 +110,10 @@ def test_and_keyword_search():
     yield (check_query, 'q=Service 1 2 3', 0, {})
 
     yield (check_query, 'q=+Service +1', 1, {})
-    yield (check_query, 'q=Service %26 100', 1, {})
-    yield (check_query, 'q=Service %26%26 100', 1, {})
+    yield (check_query, 'q=Service %26100', 1, {})
+    yield (check_query, 'q=Service %26 100', 0, {})
+    yield (check_query, 'q=Service %26%26100', 1, {})
+    yield (check_query, 'q=Service %26%26 100', 0, {})
 
 
 def test_phrase_keyword_search():
@@ -145,7 +147,8 @@ def test_or_keyword_search():
 def test_escaped_characters():
     yield (check_query, 'q=\\"Service | 12\\"', 120, {})
     yield (check_query, 'q=\-12', 1, {})
-    yield (check_query, 'q=Service \| 12', 1, {})
+    yield (check_query, 'q=Service \|12', 1, {})
+    yield (check_query, 'q=Service \| 12', 0, {})
 
 
 # Module setup and teardown
@@ -156,6 +159,7 @@ def setup_module():
     setup_authorization(app)
 
     with app.app_context():
+        test_client.put('/index-to-create')
         services = list(create_services(120))
         for service in services:
             test_client.put(


### PR DESCRIPTION
[#103575496](https://www.pivotaltracker.com/story/show/103575496)

Changes the serviceSummary mapping to make Elasticsearch use `postings`
highlighter for the service description field. Postings highlighter
fixes bugs with the unhighlighted document HTML escaping and fragment
size limits.

(https://www.elastic.co/guide/en/elasticsearch/reference/2.0/search-request-highlighting.html#postings-highlighter)

The default "plain" highlighter ignores the encoder option when nothing
was highlighted in the output, returning the truncated field text with
unescaped HTML entities, which creates an XSS vulnerability in search
results.

We could ignore the highlighter result and instead escape the original
description ourselves in this case, but we also use the highlighter to
limit the search result snippet size.

Instead, we can set a different highlighter by specifying a field option
in the index mapping.

Both `postings` and `fvh` highlighters properly encode unhighlighted
snippets. They also fix a previous issue with fragment size limit we've
run into in #51.

Setting a different highlighter requires a change to the mapping.
For `fvh` this change results in a failure to update existing index
in-place. For `postings` Elasticsearch acknowledges the mapping update,
but doesn't actually change the field option and doesn't switch the type
of the highlighter.

So this mapping change **won't be applied until the index is recreated.**