### PR TITLE
[#103675320] Add create alias action to the /<name> PUT endpoint

### DIFF
--- a/.ebextensions/indexupdate.config
+++ b/.ebextensions/indexupdate.config
@@ -1,4 +1,0 @@
-container_commands:
-  upgrade:
-    command: "python application.py update_index g-cloud"
-    leader_only: true

--- a/README.md
+++ b/README.md
@@ -98,3 +98,44 @@ Which provides a UI over the API calls.
 
 To use feature flags, check out the documentation in (the README of)
 [digitalmarketplace-utils](https://github.com/alphagov/digitalmarketplace-utils#using-featureflags).
+
+### Updating the index mapping
+
+Whenever the mappings JSON file is updated, a new version value should be written to the mapping
+metadata in `"_meta": {"version": VALUE}`.
+
+Mapping can be updated by issuing a PUT request to the existing index enpoint:
+
+```
+PUT /g-cloud-index HTTP/1.1
+Authorization: Bearer myToken
+Content-Type: application/json
+
+{"type": "index"}
+```
+
+If the mapping cannot be updated in-place, [zero-downtime mapping update process](https://www.elastic.co/blog/changing-mapping-with-zero-downtime) should be used instead:
+
+1. Create a new index, using the `index-name-YYYY-MM-DD` pattern for the new index name.
+   ```
+   PUT /g-cloud-2015-09-29 HTTP/1.1
+   Authorization: Bearer myToken
+   Content-Type: application/json
+
+   {"type": "index"}
+   ```
+2. Reindex documents into the new index using existing index document endpoints with the new index name
+3. Once the indexing is finished, update the index alias to point to the new index:
+   ```
+   PUT /g-cloud HTTP/1.1
+   Authorization: Bearer myToken
+   Content-Type: application/json
+
+   {"type": "alias", "target": "g-cloud-2015-09-29"}
+   ```
+
+4. Once the alias is updated the old index can be removed:
+   ```
+   DELETE /g-cloud-index HTTP/1.1
+   Authorization: Bearer myToken
+   ```

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -106,9 +106,11 @@ def index(index_name, doc_type, document, document_id):
 def status_for_index(index_name):
     try:
         res = es.indices.status(index=index_name, human=True)
-        return convert_es_status(res, index_name), 200
+        info = es.indices.get(index_name)
     except TransportError as e:
         return _get_an_error_message(e), e.status_code
+
+    return convert_es_status(index_name, res, info), 200
 
 
 def status_for_all_indexes():

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -30,6 +30,23 @@ def create_index(index_name):
         return _get_an_error_message(e), e.status_code
 
 
+def create_alias(alias_name, target_index):
+    """Sets an alias for a given index
+
+    If alias already exists it's removed from any existing indexes first.
+
+    """
+
+    try:
+        es.indices.update_aliases({"actions": [
+            {"remove": {"index": "_all", "alias": alias_name}},
+            {"add": {"index": target_index, "alias": alias_name}}
+        ]})
+        return "acknowledged", 200
+    except TransportError as e:
+        return _get_an_error_message(e), e.status_code
+
+
 def put_index_mapping(index_name):
     try:
         es.indices.put_mapping(

--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -2,7 +2,7 @@ from flask import jsonify, url_for, request, abort
 from app.main import main
 from app.main.services.search_service import keyword_search, \
     index, status_for_index, create_index, delete_index, \
-    status_for_all_indexes, fetch_by_id, delete_by_id, create_alias
+    fetch_by_id, delete_by_id, create_alias
 from app.main.services.process_request_json import \
     convert_request_json_into_index_json
 
@@ -64,16 +64,9 @@ def delete(index_name):
     return jsonify(message=result), status_code
 
 
-@main.route('/<string:index_name>/status', methods=['GET'])
+@main.route('/<string:index_name>', methods=['GET'])
 def status(index_name):
     result, status_code = status_for_index(index_name)
-
-    return jsonify(status=result), status_code
-
-
-@main.route('/status', methods=['GET'])
-def all_status():
-    result, status_code = status_for_all_indexes()
 
     return jsonify(status=result), status_code
 

--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -2,7 +2,7 @@ from flask import jsonify, url_for, request, abort
 from app.main import main
 from app.main.services.search_service import keyword_search, \
     index, status_for_index, create_index, delete_index, \
-    status_for_all_indexes, fetch_by_id, delete_by_id
+    status_for_all_indexes, fetch_by_id, delete_by_id, create_alias
 from app.main.services.process_request_json import \
     convert_request_json_into_index_json
 
@@ -45,7 +45,14 @@ def index_document(index_name, doc_type, service_id):
 
 @main.route('/<string:index_name>', methods=['PUT'])
 def create(index_name):
-    result, status_code = create_index(index_name)
+    create_type = get_json_from_request('type')
+    if create_type == 'index':
+        result, status_code = create_index(index_name)
+    elif create_type == 'alias':
+        alias_target = get_json_from_request('target')
+        result, status_code = create_alias(index_name, alias_target)
+    else:
+        abort(400, "Unrecognized 'type' value. Expected 'index' or 'alias'")
 
     return jsonify(message=result), status_code
 

--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -30,7 +30,7 @@ def search(index_name, doc_type):
                        services=result['services'],
                        links=result['links']), status_code
     else:
-        return jsonify(message=result), status_code
+        return api_response(result, status_code)
 
 
 @main.route('/<string:index_name>/<string:doc_type>/<string:service_id>',
@@ -40,7 +40,7 @@ def index_document(index_name, doc_type, service_id):
     index_json = convert_request_json_into_index_json(json_payload)
     result, status_code = index(index_name, doc_type, index_json, service_id)
 
-    return jsonify(message=result), status_code
+    return api_response(result, status_code)
 
 
 @main.route('/<string:index_name>', methods=['PUT'])
@@ -54,21 +54,21 @@ def create(index_name):
     else:
         abort(400, "Unrecognized 'type' value. Expected 'index' or 'alias'")
 
-    return jsonify(message=result), status_code
+    return api_response(result, status_code)
 
 
 @main.route('/<string:index_name>', methods=['DELETE'])
 def delete(index_name):
     result, status_code = delete_index(index_name)
 
-    return jsonify(message=result), status_code
+    return api_response(result, status_code)
 
 
 @main.route('/<string:index_name>', methods=['GET'])
 def status(index_name):
     result, status_code = status_for_index(index_name)
 
-    return jsonify(status=result), status_code
+    return api_response(result, status_code, key='status')
 
 
 @main.route('/<string:index_name>/<string:doc_type>/<string:service_id>',
@@ -79,7 +79,7 @@ def fetch_service(index_name, doc_type, service_id):
     if status_code == 200:
         return jsonify(services=result), status_code
     else:
-        return jsonify(message=result), status_code
+        return api_response(result, status_code)
 
 
 @main.route('/<string:index_name>/<string:doc_type>/<string:service_id>',
@@ -87,7 +87,14 @@ def fetch_service(index_name, doc_type, service_id):
 def delete_service(index_name, doc_type, service_id):
     result, status_code = delete_by_id(index_name, doc_type, service_id)
 
-    return jsonify(message=result), status_code
+    return api_response(result, status_code)
+
+
+def api_response(data, status_code, key='message'):
+    if status_code // 100 == 2:
+        return jsonify({key: data}), status_code
+    else:
+        return jsonify(error=data), status_code
 
 
 def check_json_from_request(request):

--- a/example_es_responses/index_info.json
+++ b/example_es_responses/index_info.json
@@ -1,0 +1,52 @@
+{
+  "g-cloud": {
+    "aliases": {
+      "galias": {}
+    },
+    "mappings": {
+      "services": {
+        "dynamic": "strict",
+        "_meta": {
+          "version": "2015-09-28"
+        },
+        "properties": {}
+      }
+    },
+    "settings": {
+      "index": {
+        "creation_date": "1443534824067",
+        "number_of_shards": "5",
+        "number_of_replicas": "1",
+        "version": {
+          "created": "1070199"
+        },
+        "uuid": "uEDxiMU5SaGCMMsXAmMepg"
+      }
+    },
+    "warmers": {}
+  },
+  "g-cloud-new": {
+    "aliases": {},
+    "mappings": {
+      "services": {
+        "dynamic": "strict",
+        "_meta": {
+          "version": "2015-09-28"
+        },
+        "properties": {}
+      }
+    },
+    "settings": {
+      "index": {
+        "creation_date": "1443534817736",
+        "number_of_shards": "5",
+        "number_of_replicas": "1",
+        "version": {
+          "created": "1070199"
+        },
+        "uuid": "EF3FQS0YSTmrLuxYuUJNSA"
+      }
+    },
+    "warmers": {}
+  }
+}

--- a/mappings/services.json
+++ b/mappings/services.json
@@ -1,6 +1,9 @@
 {
   "mappings": {
     "services": {
+      "_meta": {
+          "version": "2015-09-28"
+      },
       "dynamic": "strict",
       "properties": {
         "id": {

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import os
+import json
 
 from app import create_app
 
@@ -27,6 +28,13 @@ class BaseApplicationTest(object):
 
     def do_not_provide_access_token(self):
         self.app.wsgi_app = self.app.wsgi_app.app
+
+    def create_index(self, index_name=None):
+        if index_name is None:
+            index_name = self.default_index_name
+        return self.client.put('/{}'.format(index_name), data=json.dumps({
+            "type": "index"
+        }), content_type="application/json")
 
     def teardown(self):
         self.client.delete('/' + self.default_index_name)

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -4,6 +4,7 @@ import os
 import json
 
 from app import create_app
+from app import elasticsearch_client
 
 
 class WSGIApplicationWithEnvironment(object):
@@ -37,7 +38,8 @@ class BaseApplicationTest(object):
         }), content_type="application/json")
 
     def teardown(self):
-        self.client.delete('/' + self.default_index_name)
+        with self.app.app_context():
+            elasticsearch_client.indices.delete('index-*')
         teardown_authorization()
 
 

--- a/tests/app/services/test_response_formatters.py
+++ b/tests/app/services/test_response_formatters.py
@@ -7,6 +7,9 @@ from app.main.services.response_formatters import \
 with open("example_es_responses/status.json") as services:
     STATUS_JSON = json.load(services)
 
+with open("example_es_responses/index_info.json") as services:
+    INDEX_INFO_JSON = json.load(services)
+
 with open("example_es_responses/search_results.json") as search_results:
     SEARCH_RESULTS_JSON = json.load(search_results)
 
@@ -59,14 +62,22 @@ def test_should_not_include_highlights_if_not_in_es_results():
 
 
 def test_should_build_status_response_from_es_response():
-    res = convert_es_status(STATUS_JSON, "g-cloud")
-    assert_equal(res["num_docs"], 10380)
-    assert_equal(res["primary_size"], "16.8mb")
+    res = convert_es_status("g-cloud", STATUS_JSON, INDEX_INFO_JSON)
+    assert_equal(res, {
+        "num_docs": 10380,
+        "primary_size": "16.8mb",
+        "mapping_version": "2015-09-28",
+        "aliases": ["galias"],
+    })
 
 
 def test_should_build_status_response_from_es_response_with_empty_index():
     status_json_with_no_docs = dict(STATUS_JSON)
     del status_json_with_no_docs["indices"]["g-cloud"]["docs"]
-    res = convert_es_status(status_json_with_no_docs, "g-cloud")
-    assert_equal("num_docs" in res, False)
-    assert_equal(res["primary_size"], "16.8mb")
+    res = convert_es_status("g-cloud", status_json_with_no_docs)
+    assert_equal(res, {
+        "aliases": [],
+        "mapping_version": None,
+        "num_docs": None,
+        "primary_size": "16.8mb",
+    })

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -16,7 +16,7 @@ class TestSearchIndexes(BaseApplicationTest):
         assert_equal(get_json_from_response(response)["message"],
                      "acknowledged")
 
-        response = self.client.get('/index-to-create/status')
+        response = self.client.get('/index-to-create')
         assert_equal(response.status_code, 200)
 
         response = self.client.delete('/index-to-create')
@@ -24,7 +24,7 @@ class TestSearchIndexes(BaseApplicationTest):
         assert_equal(get_json_from_response(response)["message"],
                      "acknowledged")
 
-        response = self.client.get('/index-to-create/status')
+        response = self.client.get('/index-to-create')
         assert_equal(response.status_code, 404)
 
     def test_should_be_able_to_create_aliases(self):
@@ -100,7 +100,7 @@ class TestSearchIndexes(BaseApplicationTest):
                      in get_json_from_response(response)["message"], True)
 
     def test_should_return_404_if_no_index(self):
-        response = self.client.get('/index-does-not-exist/status')
+        response = self.client.get('/index-does-not-exist')
         assert_equal(response.status_code, 404)
         assert_equal(
             "IndexMissingException[[index-does-not-exist] missing]" in
@@ -125,7 +125,7 @@ class TestIndexingDocuments(BaseApplicationTest):
 
         with self.app.app_context():
             search_service.refresh('index-to-create')
-        response = self.client.get('/index-to-create/status')
+        response = self.client.get('/index-to-create')
         assert_equal(response.status_code, 200)
         assert_equal(
             get_json_from_response(response)["status"]["num_docs"],

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -44,7 +44,7 @@ class TestSearchIndexes(BaseApplicationTest):
         }), content_type="application/json")
 
         assert_equal(response.status_code, 404)
-        assert_in("IndexMissingException", get_json_from_response(response)["message"])
+        assert_in("IndexMissingException", get_json_from_response(response)["error"])
 
     def test_cant_replace_index_with_alias(self):
         self.create_index()
@@ -54,7 +54,7 @@ class TestSearchIndexes(BaseApplicationTest):
         }), content_type="application/json")
 
         assert_equal(response.status_code, 400)
-        assert_in("InvalidAliasNameException", get_json_from_response(response)["message"])
+        assert_in("InvalidAliasNameException", get_json_from_response(response)["error"])
 
     def test_can_update_alias(self):
         self.create_index()
@@ -97,14 +97,14 @@ class TestSearchIndexes(BaseApplicationTest):
         response = self.client.delete('/index-to-create')
         assert_equal(response.status_code, 404)
         assert_equal("IndexMissingException[[index-to-create] missing]"
-                     in get_json_from_response(response)["message"], True)
+                     in get_json_from_response(response)["error"], True)
 
     def test_should_return_404_if_no_index(self):
         response = self.client.get('/index-does-not-exist')
         assert_equal(response.status_code, 404)
         assert_equal(
             "IndexMissingException[[index-does-not-exist] missing]" in
-            get_json_from_response(response)["status"],
+            get_json_from_response(response)["error"],
             True)
 
 
@@ -508,7 +508,7 @@ class TestDeleteById(BaseApplicationTest):
             '/index-to-create/services/' + str(service["service"]["id"]))
         data = get_json_from_response(response)
         assert_equal(response.status_code, 404)
-        assert_equal(data['message']['found'], False)
+        assert_equal(data['error']['found'], False)
 
     def test_should_return_404_if_no_service(self):
         self.create_index()
@@ -518,7 +518,7 @@ class TestDeleteById(BaseApplicationTest):
 
         data = get_json_from_response(response)
         assert_equal(response.status_code, 404)
-        assert_equal(data['message']['found'], False)
+        assert_equal(data['error']['found'], False)
 
 
 def create_services(number_of_services):

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -11,7 +11,7 @@ from ..helpers import BaseApplicationTest, default_service
 
 class TestSearchIndexes(BaseApplicationTest):
     def test_should_be_able_create_and_delete_index(self):
-        response = self.client.put('/index-to-create')
+        response = self.create_index()
         assert_equal(response.status_code, 200)
         assert_equal(get_json_from_response(response)["message"],
                      "acknowledged")
@@ -28,13 +28,13 @@ class TestSearchIndexes(BaseApplicationTest):
         assert_equal(response.status_code, 404)
 
     def test_creating_existing_index_updates_mapping(self):
-        self.client.put('/index-to-create')
+        self.create_index()
 
         with self.app.app_context():
             with mock.patch(
                 'app.main.services.search_service.es.indices.put_mapping'
             ) as es_mock:
-                response = self.client.put('/index-to-create')
+                response = self.create_index()
 
         assert_equal(response.status_code, 200)
         assert_equal("acknowledged", get_json_from_response(response)["message"])
@@ -45,7 +45,7 @@ class TestSearchIndexes(BaseApplicationTest):
         )
 
     def test_should_not_be_able_delete_index_twice(self):
-        self.client.put('/index-to-create')
+        self.create_index()
         self.client.delete('/index-to-create')
         response = self.client.delete('/index-to-create')
         assert_equal(response.status_code, 404)
@@ -64,7 +64,7 @@ class TestSearchIndexes(BaseApplicationTest):
 class TestIndexingDocuments(BaseApplicationTest):
     def setup(self):
         super(TestIndexingDocuments, self).setup()
-        self.client.put('/index-to-create')
+        self.create_index()
 
     def test_should_index_a_document(self):
         service = default_service()
@@ -133,7 +133,7 @@ class TestIndexingDocuments(BaseApplicationTest):
 class TestSearchEndpoint(BaseApplicationTest):
     def setup(self):
         super(TestSearchEndpoint, self).setup()
-        self.client.put('/index-to-create')
+        self.create_index()
         with self.app.app_context():
             services = create_services(10)
             for service in services:
@@ -464,7 +464,7 @@ class TestDeleteById(BaseApplicationTest):
         assert_equal(data['message']['found'], False)
 
     def test_should_return_404_if_no_service(self):
-        self.client.put('/index-to-create')
+        self.create_index()
 
         response = self.client.delete(
             '/index-to-create/delete/100')

--- a/tests/app/views/test_search_queries.py
+++ b/tests/app/views/test_search_queries.py
@@ -159,7 +159,11 @@ def setup_module():
     setup_authorization(app)
 
     with app.app_context():
-        test_client.put('/index-to-create')
+        test_client.put(
+            '/index-to-create',
+            data=json.dumps({"type": "index"}),
+            content_type="application/json",
+        )
         services = list(create_services(120))
         for service in services:
             test_client.put(


### PR DESCRIPTION
#### Add create alias action to the /<name> PUT endpoint
Allows creating aliases instead of indexes using the existing PUT
endpoint. PUT request would either create a new alias or replace
an existing one with an alias to a given target.

PUT /<name> now expects a JSON payload with "type" key.
"type" could be "index" or "alias".

DELETE endpoint only supports indexes at the moment and there's no
way to delete an alias.

#### Add mapping version and aliases list to index status response
Adds information about index aliases and mapping version to the
index status response and the /_status endpoint.

Moved /index-name/status endpoint to /index-name.

Mapping version is stored in the mapping "_meta" field and should be
manually changed each time the mapping is modified.

#### Remove automatic index migration
Automatic migration will fail if there's a conflict in the mapping
update. Since resolving a conflict requires a reindexing it should
be done outside the deployment process.

Recommended mapping update/reindex process is added to the README.