### PR TITLE
Use response headers to log requestId from apache

### DIFF
--- a/.ebextensions/apache_log.config
+++ b/.ebextensions/apache_log.config
@@ -4,8 +4,8 @@ files:
     owner: root
     group: root
     content: |
-      LogFormat "apache-access search-api \"%{DM-Request-ID}i\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" cloudwatchlogs
+      LogFormat "apache-access search-api \"%{DM-Request-ID}o\" %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" cloudwatchlogs
       CustomLog logs/cwl_access_log cloudwatchlogs
 
-      LogFormat "{ \"application\": \"search-api\", \"logType\": \"apache-access\", \"requestId\": \"%{DM-Request-ID}i\", \"remoteHost\": \"%h\", \"remoteLogname\": \"%l\", \"user\": \"%u\", \"time\": \"%t\", \"request\": \"%r\", \"status\": %>s, \"size\": %b, \"referer\": \"%{Referer}i\", \"userAgent\": \"%{User-Agent}i\", \"requestTimeMicro\": %D, \"requestPath\": \"%U\"}" cloudwatchjsonlogs
+      LogFormat "{ \"application\": \"search-api\", \"logType\": \"apache-access\", \"requestId\": \"%{DM-Request-ID}o\", \"remoteHost\": \"%h\", \"remoteLogname\": \"%l\", \"user\": \"%u\", \"time\": \"%t\", \"request\": \"%r\", \"status\": %>s, \"size\": %b, \"referer\": \"%{Referer}i\", \"userAgent\": \"%{User-Agent}i\", \"requestTimeMicro\": %D, \"requestPath\": \"%U\"}" cloudwatchjsonlogs
       CustomLog logs/cwl_access_log.json cloudwatchjsonlogs


### PR DESCRIPTION
Request headers are only set on requests to the API from the frontend
apps, but response headers are set by a WSGI middleware for all
responses.