### PR TITLE
Use Fast Vector Highlighter for serviceSummary field

### DIFF
--- a/mappings/services.json
+++ b/mappings/services.json
@@ -2,7 +2,7 @@
   "mappings": {
     "services": {
       "_meta": {
-          "version": "2015-09-28"
+          "version": "2015-10-12"
       },
       "dynamic": "strict",
       "properties": {
@@ -22,7 +22,7 @@
           "type": "string"
         },
         "serviceSummary": {
-          "index_options" : "offsets",
+          "term_vector" : "with_positions_offsets",
           "type": "string"
         },
         "serviceBenefits": {

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -4,7 +4,7 @@ import re
 from app.main.services.process_request_json import process_values_for_matching
 from app.main.services import search_service
 from flask import json
-from nose.tools import assert_equal, assert_in, assert_less
+from nose.tools import assert_equal, assert_in, assert_true
 
 from ..helpers import BaseApplicationTest, default_service
 
@@ -353,7 +353,7 @@ class TestSearchEndpoint(BaseApplicationTest):
         stripped_search_results = re.sub(
             "<[^<]+?>", "", search_results[0]["highlight"]["serviceSummary"][0]
         )
-        assert_less(len(stripped_search_results), 400)
+        assert_true(390 < len(stripped_search_results) < 410)
 
     def test_highlight_service_summary_limited_if_no_matches(self):
 
@@ -375,7 +375,7 @@ class TestSearchEndpoint(BaseApplicationTest):
         search_results = get_json_from_response(response)["services"]
         # Get the first with a matching value from a list
         search_result = next((s for s in search_results if s['lot'] == 'TaaS'), None)
-        assert_less(len(search_result["highlight"]["serviceSummary"][0]), 400)
+        assert_true(390 < len(search_result["highlight"]["serviceSummary"][0]) < 410)
 
 
 class TestFetchById(BaseApplicationTest):


### PR DESCRIPTION
Postings highlighter doesn't support fragment_size options and
will always return one sentence if `no_match_size` is set. Search
result size can only be controlled by setting the number of sentences
that will be returned for each result, which is less precise than
the character limit we have now.

Switching to fvh keeps the existing search snippet size settings
while fixing the encoding issue caused by the plain highlighter.