### PR TITLE
Disable deleting an alias or aliased index directly

### DIFF
--- a/app/main/services/response_formatters.py
+++ b/app/main/services/response_formatters.py
@@ -14,7 +14,10 @@ def convert_es_status(index_name, status_response, info_response=None):
 
 
 def _convert_es_index_status(index_name, status_response, info_response):
-    index_status = status_response['indices'][index_name]
+    index_status = status_response['indices'].get(index_name, {})
+    if not index_status:
+        return index_status
+
     index_mapping = info_response.get(index_name, {}).get('mappings', {}).get("services", {})
     index_aliases = info_response.get(index_name, {}).get('aliases', {})
 

--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -59,6 +59,20 @@ def create(index_name):
 
 @main.route('/<string:index_name>', methods=['DELETE'])
 def delete(index_name):
+    status, status_code = status_for_index(index_name)
+
+    if status_code != 200:
+        return api_response(status, status_code)
+
+    if not status:
+        return api_response("Cannot delete alias '{}'".format(index_name), 400)
+
+    if status.get('aliases'):
+        return api_response(
+            "Index '{}' is aliased as '{}' and cannot be deleted".format(
+                index_name, status['aliases'][0]
+            ), 400)
+
     result, status_code = delete_index(index_name)
 
     return api_response(result, status_code)

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -37,6 +37,33 @@ class TestSearchIndexes(BaseApplicationTest):
         assert_equal(response.status_code, 200)
         assert_equal(get_json_from_response(response)["message"], "acknowledged")
 
+    def test_should_not_be_able_to_delete_aliases(self):
+        self.create_index()
+        self.client.put('/index-alias', data=json.dumps({
+            "type": "alias",
+            "target": "index-to-create"
+        }), content_type="application/json")
+
+        response = self.client.delete('/index-alias')
+
+        assert_equal(response.status_code, 400)
+        assert_equal(get_json_from_response(response)["error"], "Cannot delete alias 'index-alias'")
+
+    def test_should_not_be_able_to_delete_index_with_alias(self):
+        self.create_index()
+        self.client.put('/index-alias', data=json.dumps({
+            "type": "alias",
+            "target": "index-to-create"
+        }), content_type="application/json")
+
+        response = self.client.delete('/index-to-create')
+
+        assert_equal(response.status_code, 400)
+        assert_equal(
+            get_json_from_response(response)["error"],
+            "Index 'index-to-create' is aliased as 'index-alias' and cannot be deleted"
+        )
+
     def test_cant_create_alias_for_missing_index(self):
         response = self.client.put('/index-alias', data=json.dumps({
             "type": "alias",


### PR DESCRIPTION
Deleting an alias using `es.indices.delete` deletes the underlying
index instead. To avoid accidental deletion index status is checked
first:

* If index name points to an alias, delete request fails with 400.
  Aliases should be changed using the PUT endpoint.

* If index HAS an alias, delete request fails with 400. This is a
  safety measure to avoid accidental deletion of indexes that are
  being used by the application.

* Otherwise, the result of the index deletion request is returned.