### PR TITLE
Remove service description text truncation

### DIFF
--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -37,12 +37,11 @@ def highlight_clause():
     }
     highlights["fields"] = {}
 
+    # Get all fields searched and allow non-matches to a max of the searchSummary limit
     for field in TEXT_FIELDS:
-        # 400 characters is generally >= 50 words
         highlights["fields"][field] = {
-            "number_of_fragments": 1,
-            "fragment_size": 400,
-            "no_match_size": 400
+            "number_of_fragments": 0,
+            "no_match_size": 500
         }
 
     return highlights

--- a/tests/app/services/test_query_builder.py
+++ b/tests/app/services/test_query_builder.py
@@ -234,16 +234,6 @@ def test_highlight_block_contains_correct_fields():
             example
 
 
-def test_highlight_block_character_length_for_service_summary():
-    query = construct_query(
-        build_query_params(keywords="some keywords",
-                           service_types=["some serviceTypes"]))
-
-    assert_equal("highlight" in query, True)
-    assert_equal(query["highlight"]["fields"]["serviceSummary"]["no_match_size"], 400)
-    assert_equal(query["highlight"]["fields"]["serviceSummary"]["fragment_size"], 400)
-
-
 def build_query_params(keywords=None, service_types=None, lot=None, page=None):
     query_params = MultiDict()
     if keywords:

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -361,31 +361,10 @@ class TestSearchEndpoint(BaseApplicationTest):
             "Oh &lt;script&gt;alert(&quot;Yo&quot;);&lt;&#x2F;script&gt;"
         )
 
-    def test_highlight_service_summary_limited_if_search_string_matches(self):
-
-        # 200 words, 1000 characters
-        really_long_service_summary = "This line has a total of 10 words, 50 characters. " * 20
-
-        service = default_service(
-            serviceSummary=really_long_service_summary
-        )
-
-        response = self._put_into_and_get_back_from_elasticsearch(
-            service=service,
-            query_string='q=characters'
-        )
-        assert_equal(response.status_code, 200)
-
-        search_results = get_json_from_response(response)["services"]
-        stripped_search_results = re.sub(
-            "<[^<]+?>", "", search_results[0]["highlight"]["serviceSummary"][0]
-        )
-        assert_true(390 < len(stripped_search_results) < 410)
-
     def test_highlight_service_summary_limited_if_no_matches(self):
 
-        # 200 words, 1000 characters
-        really_long_service_summary = "This line has a total of 10 words, 50 characters. " * 20
+        # 120 words, 600 characters
+        really_long_service_summary = "This line has a total of 10 words, 50 characters. " * 12
 
         service = default_service(
             serviceSummary=really_long_service_summary,
@@ -402,7 +381,7 @@ class TestSearchEndpoint(BaseApplicationTest):
         search_results = get_json_from_response(response)["services"]
         # Get the first with a matching value from a list
         search_result = next((s for s in search_results if s['lot'] == 'TaaS'), None)
-        assert_true(390 < len(search_result["highlight"]["serviceSummary"][0]) < 410)
+        assert_true(490 < len(search_result["highlight"]["serviceSummary"][0]) < 510)
 
 
 class TestFetchById(BaseApplicationTest):


### PR DESCRIPTION
Until now, we've truncated the search summary text for each search result to 400 characters. Now there are no G5 services on production there is now reason to do so.

https://www.pivotaltracker.com/story/show/109270496

#### Notes

`no_match_size` is set because elasticsearch will only return highlight data if a match is found in one of the fields searched (set in `mappings/services.json`).

We need the summary text for each search result to be a copy of the `searchSummary` field in the `highlights` data so any HTML it contains is escaped (by setting the [encoder](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html#_encoder) to 'html'). 

(See https://github.com/alphagov/digitalmarketplace-search-api/blob/master/app/main/services/query_builder.py#L34)

Setting `no_match_size` means highlight data is always returned so the `searchSummary` field is always escaped.