### PR TITLE
Update README-install specific version of elasticsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install [elasticsearch](http://www.elasticsearch.org/)
 
 ```
 brew update
-brew install elasticsearch
+brew install homebrew/versions/elasticsearch17
 ```
 
 Install [Virtualenv](https://virtualenv.pypa.io/en/latest/)


### PR DESCRIPTION
Latest version of elasticsearch(2.x.x) is posing a problem specifying the version that works to be used during install