### PR TITLE
Add makefile and switch to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ python:
   - "2.7"
   - "3.4"
 install:
-  - pip install -r requirements_for_test.txt
+  - make requirements_for_test
 script:
-  - ./scripts/run_tests.sh
+  - PYTEST_ARGS='--cov=app --cov-report=term-missing' make test
 notifications:
   email: false
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+SHELL := /bin/bash
+VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
+
+run_all: requirements run_app
+
+run_app: virtualenv
+	${VIRTUALENV_ROOT}/bin/python application.py runserver
+
+virtualenv:
+	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv venv || true
+
+requirements: virtualenv requirements.txt
+	${VIRTUALENV_ROOT}/bin/pip install -r requirements.txt
+
+requirements_for_test: virtualenv requirements_for_test.txt
+	${VIRTUALENV_ROOT}/bin/pip install -r requirements_for_test.txt
+
+test: test_pep8 test_unit
+
+test_pep8: virtualenv
+	${VIRTUALENV_ROOT}/bin/pep8 .
+
+test_unit: virtualenv
+	${VIRTUALENV_ROOT}/bin/py.test ${PYTEST_ARGS}
+
+.PHONY: virtualenv requirements requirements_for_test test_pep8 test_unit test run_app run_all

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ API to handle interactions between the digitalmarketplace applications and searc
 
 ## Setup
 
-Install [elasticsearch](http://www.elasticsearch.org/)
+Install [elasticsearch](http://www.elasticsearch.org/). This must be in the 1.x series not the 2.x series.
 
 ```
 brew update

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,3 +2,6 @@
 pytest==2.9.1
 pep8==1.5.7
 mock==1.0.1
+coverage==3.7.1
+pytest-cov==2.2.0
+python-coveralls==2.5.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
-nose==1.3.4
+pytest==2.9.1
 pep8==1.5.7
 mock==1.0.1

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -30,5 +30,5 @@ function display_result {
 pep8 .
 display_result $? 1 "Code style check"
 
-nosetests -v -s --with-doctest --logging-level=CRITICAL
+py.test $@
 display_result $? 2 "Unit tests"


### PR DESCRIPTION
Add Makefile and switch to pytest, brings the search API in line with the other apps.
Be really clear about elasticsearch version