### PR TITLE
Fix venv test failures

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 pytest==2.9.1
+nose==1.3.4  # nose.tools is still imported by tests
 pep8==1.5.7
 mock==1.0.1
 coverage==3.7.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [pep8]
 exclude = ./venv
 max-line-length = 120
+
+[pytest]
+norecursedirs = venv


### PR DESCRIPTION
### Don't look for test files inside local virtualenv
We set py.test norecursedirs for other repos to stop py.test from gathering test files inside virtualenv folder when using local virtualenv (as opposed to the one installed by virtualenvwrapper)

### Restore nose test requirement
Test files are still importing nose.tools even though we're using py.test as a test runner now.

This didn't cause an issue with Travis since Travis environments seem to have nosetools preinstalled.