### PR TITLE
Read dev and test auth tokens from the app config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ sudo easy_install virtualenv
 
 Create a virtual environment in the checked-out repository folder
 
- ```
-cd digitalmarketplace-search-api
-virtualenv ./venv
- ```
+```
+make virtualenv
+```
 
 ### Activate the virtual environment
 
@@ -35,7 +34,9 @@ source ./venv/bin/activate
 
 Install Python dependencies with pip
 
-```pip install -r requirements_for_test.txt```
+```
+make requirements_for_test
+```
 
 ### Insert G6 services into elasticsearch index
 
@@ -58,7 +59,7 @@ export DM_ELASTICSEARCH_URL=http://localhost:9200
 ### Run the tests
 
 ```
-./scripts/run_tests.sh
+make test
 ```
 
 ### Run the development server
@@ -66,7 +67,7 @@ export DM_ELASTICSEARCH_URL=http://localhost:9200
 To run the Search API for local development you can use the convenient run
 script, which sets the required environment variables for local development:
 ```
-./scripts/run_app.sh
+make run_app
 ```
 
 More generally, the command to start the server is:

--- a/app/authentication.py
+++ b/app/authentication.py
@@ -14,25 +14,12 @@ def requires_authentication():
 
 
 def token_is_valid(incoming_token):
-    return incoming_token in get_allowed_tokens_from_environment()
+    return incoming_token in get_allowed_tokens_from_config(current_app.config)
 
 
-def get_allowed_tokens_from_environment():
-    """Return a list of allowed auth tokens from the DM_API_AUTH_TOKENS env
-       variable
-
-    >>> os.environ['DM_SEARCH_API_AUTH_TOKENS'] = ''
-    >>> list(get_allowed_tokens_from_environment())
-    []
-    >>> del os.environ['DM_SEARCH_API_AUTH_TOKENS']
-    >>> list(get_allowed_tokens_from_environment())
-    []
-    >>> os.environ['DM_SEARCH_API_AUTH_TOKENS'] = 'ab:cd'
-    >>> list(get_allowed_tokens_from_environment())
-    ['ab', 'cd']
-    """
-    return filter(None,
-                  os.environ.get('DM_SEARCH_API_AUTH_TOKENS', '').split(":"))
+def get_allowed_tokens_from_config(config):
+    """Return a list of allowed auth tokens from application config"""
+    return [token for token in config.get('DM_SEARCH_API_AUTH_TOKENS', '').split(':') if token]
 
 
 def get_token_from_headers(headers):

--- a/config.py
+++ b/config.py
@@ -34,10 +34,14 @@ class Test(Config):
     DEBUG = True
     DM_LOG_LEVEL = 'CRITICAL'
 
+    DM_SEARCH_API_AUTH_TOKENS = 'valid-token'
+
 
 class Development(Config):
     DEBUG = True
     DM_SEARCH_PAGE_SIZE = 5
+
+    DM_SEARCH_API_AUTH_TOKENS = 'myToken'
 
 
 class Live(Config):

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -5,10 +5,6 @@ else
   source ./venv/bin/activate 2>/dev/null && echo "Virtual environment activated."
 fi
 
-# Use default environment vars for localhost if not already set
-export DM_SEARCH_API_AUTH_TOKENS=${DM_SEARCH_API_AUTH_TOKENS:=myToken}
-export DM_ELASTICSEARCH_URL=${DM_ELASTICSEARCH_URL:=http://localhost:9200}
-
 echo "Environment variables in use:"
 env | grep DM_
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,10 +5,6 @@
 # NOTE: This script expects to be run from the project root with
 # ./scripts/run_tests.sh
 
-# Use default environment vars for localhost if not already set
-export DM_SEARCH_API_AUTH_TOKENS=${DM_SEARCH_API_AUTH_TOKENS:=myToken}
-export DM_ELASTICSEARCH_URL=${DM_ELASTICSEARCH_URL:=http://localhost:9200}
-
 echo "Environment variables in use:"
 env | grep DM_
 

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -40,20 +40,13 @@ class BaseApplicationTest(object):
     def teardown(self):
         with self.app.app_context():
             elasticsearch_client.indices.delete('index-*')
-        teardown_authorization()
 
 
 def setup_authorization(app):
     """Set up bearer token and pass on all requests"""
-    valid_token = 'valid-token'
     app.wsgi_app = WSGIApplicationWithEnvironment(
         app.wsgi_app,
-        HTTP_AUTHORIZATION='Bearer {}'.format(valid_token))
-    os.environ['DM_SEARCH_API_AUTH_TOKENS'] = valid_token
-
-
-def teardown_authorization():
-    del os.environ['DM_SEARCH_API_AUTH_TOKENS']
+        HTTP_AUTHORIZATION='Bearer {}'.format(app.config['DM_SEARCH_API_AUTH_TOKENS']))
 
 
 def default_service(**kwargs):

--- a/tests/app/views/test_search_queries.py
+++ b/tests/app/views/test_search_queries.py
@@ -3,7 +3,7 @@ from flask import json
 from nose.tools import assert_equal, ok_
 
 from app import create_app
-from ..helpers import setup_authorization, teardown_authorization
+from ..helpers import setup_authorization
 from ..helpers import default_service
 
 
@@ -178,7 +178,6 @@ def teardown_module():
     test_client = app.test_client()
 
     test_client.delete('/index-to-create')
-    teardown_authorization()
 
 
 # '/search' request helpers


### PR DESCRIPTION
Removes the need to set environment variables with a list of tokens when running the search-api locally, similar to how this works in the Data API.

Also replaces test authentication setup/teardown with a test config tokens value.