### PR TITLE
Set initial DM_SEARCH_API_AUTH_TOKENS value to None

### DIFF
--- a/config.py
+++ b/config.py
@@ -14,6 +14,8 @@ class Config:
 
     ELASTICSEARCH_HOST = os.getenv('DM_ELASTICSEARCH_URL', 'localhost:9200')
 
+    DM_SEARCH_API_AUTH_TOKENS = None
+
     DM_SEARCH_PAGE_SIZE = 100
     # Logging
     DM_LOG_LEVEL = 'DEBUG'


### PR DESCRIPTION
Flask only looks up environment variables for flags defined in the config, so to get the production environment to be applied the key should have an initial value in the common preview, staging and production config.