### PR TITLE
Install libffi-dev on the ElasticBeanstalk environments

### DIFF
--- a/.ebextensions/packages.config
+++ b/.ebextensions/packages.config
@@ -1,3 +1,4 @@
 packages:
   yum:
+    libffi-devel: []
     git: []


### PR DESCRIPTION
We've added cffi to requirements.txt for PaaS, since dmutils depends
on it.

PaaS requires specifying python dependencies that require a C library
in the application requirements.txt, which it parses to install the
required system packages.

For Elastic Beanstalk we need to specify the list of packages
manually in .ebextensions