### PR TITLE
Fix local search-api port to 5001

### DIFF
--- a/application.py
+++ b/application.py
@@ -7,7 +7,7 @@ from dmutils import init_manager
 from app import create_app
 
 application = create_app(os.getenv('DM_ENVIRONMENT') or 'development')
-manager = init_manager(application, 5000, ['./json_schemas'])
+manager = init_manager(application, 5001, ['./mappings'])
 
 
 @manager.command


### PR DESCRIPTION
When upgrading dmutils I've copied the new `init_manager` code from
the API but forgot to update the port.

Also adds mappings to the list of watched locations for the development
server, so the app will restart if the files are modified.