### PR TITLE
Add service categories filter.

### DIFF
--- a/mappings/services.json
+++ b/mappings/services.json
@@ -108,7 +108,16 @@
         "filter_elasticCloud": {
           "type": "boolean",
           "index": "not_analyzed"
+        },
+
+        "serviceCategories": {
+          "type": "string"
+        },
+        "filter_serviceCategories": {
+          "type": "string",
+          "index": "not_analyzed"
         }
+
       }
     }
   }


### PR DESCRIPTION
 - question name changed between G-Cloud-8 and G-Cloud-9
 - we'll need to remove the old 'service types' filter at some point after
   go-live.

https://trello.com/b/yXdcOenW/g9-catalogues-sprint-in-progress