### PR TITLE
Set up docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+*
+
+!app/
+!application.py
+!config.py
+!mappings/
+!requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM digitalmarketplace/base-api

--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,14 @@ test_pep8: virtualenv
 test_unit: virtualenv
 	${VIRTUALENV_ROOT}/bin/py.test ${PYTEST_ARGS}
 
-.PHONY: virtualenv requirements requirements_for_test test_pep8 test_unit test run_app run_all
+docker-build:
+	$(if ${RELEASE_NAME},,$(eval export RELEASE_NAME=$(shell git describe)))
+	@echo "Building a docker image for ${RELEASE_NAME}..."
+	docker build --pull -t digitalmarketplace/search-api --build-arg release_name=${RELEASE_NAME} .
+	docker tag digitalmarketplace/search-api digitalmarketplace/search-api:${RELEASE_NAME}
+
+docker-push:
+	$(if ${RELEASE_NAME},,$(eval export RELEASE_NAME=$(shell git describe)))
+	docker push digitalmarketplace/search-api:${RELEASE_NAME}
+
+.PHONY: virtualenv requirements requirements_for_test test_pep8 test_unit test run_app run_all docker-build docker-push


### PR DESCRIPTION
Adds Dockerfile and a make build-docker task.
New image is build on the base-api image, which has the ONBUILD
commands required to install api dependencies and copy the app
files.

This also adds a whitelist dockerignore. By default, docker will
use everything in the current directory (including eg .git) as
the build context and since our base images use `COPY .` the files
end up in the public container.

To avoid accidentally pushing any sensitive / modified files we're
using the .dockerignore as a whitelist: it will only copy the files
that are matched by the `!...` patterns.

Any new top-level files or directories used either during the app
runtime or the docker build process will need to be added to the
.dockerignore list or they won't be accessible from the image.