### PR TITLE
Remove plain text logs in live

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,6 +20,7 @@ class Config:
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
     DM_APP_NAME = 'search-api'
+    DM_PLAIN_TEXT_LOGS = False
     DM_LOG_PATH = None
     DM_REQUEST_ID_HEADER = 'DM-Request-ID'
     DM_DOWNSTREAM_REQUEST_ID_HEADER = 'X-Amz-Cf-Id'
@@ -34,6 +35,7 @@ class Config:
 
 class Test(Config):
     DEBUG = True
+    DM_PLAIN_TEXT_LOGS = True
     DM_LOG_LEVEL = 'CRITICAL'
 
     DM_SEARCH_API_AUTH_TOKENS = 'valid-token'
@@ -41,6 +43,7 @@ class Test(Config):
 
 class Development(Config):
     DEBUG = True
+    DM_PLAIN_TEXT_LOGS = True
     DM_SEARCH_PAGE_SIZE = 5
 
     DM_SEARCH_API_AUTH_TOKENS = 'myToken'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask-Script==2.0.5
 six==1.9.0
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@25.0.1#egg=digitalmarketplace-utils==25.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@25.2.0#egg=digitalmarketplace-utils==25.2.0
 
 # Elasticsearch 1.0
 elasticsearch>=1.0.0,<2.0.0


### PR DESCRIPTION
Trello card: https://trello.com/c/o3Jkp3rK

25.2.0 of utils will create json logs by default, unless the
`DM_PLAIN_TEXT_LOGS` config variable is set to True in the config.

This config variable is set in dev and test so that logs are more
legible/useful.

The other thing 25.2.0 does is log to stdout instead of file by default,
unless the `DM_LOG_PATH` config variable is set. In the PaaS
environment, we'll need to log to stdout so will overwrite this
variable. Logging to stdout is also more useful in dev and test.