### PR TITLE
Fix insecure request warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:1.0.2
+FROM digitalmarketplace/base-api:1.0.3

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,7 +19,10 @@ def create_app(config_name):
         feature_flags=feature_flags
     )
 
-    elasticsearch_client.init_app(application)
+    elasticsearch_client.init_app(
+        application,
+        verify_certs=True
+    )
 
     from .main import main as main_blueprint
     from .status import status as status_blueprint

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ git+https://github.com/alphagov/digitalmarketplace-utils.git@25.2.0#egg=digitalm
 
 # Elasticsearch 1.0
 elasticsearch>=1.0.0,<2.0.0
-Flask-Elasticsearch==0.2.1
+Flask-Elasticsearch==0.2.5
 
 # For Cloud Foundry
 cffi==1.5.2


### PR DESCRIPTION
### Upgrade Flask-Elasitcsearch to 0.2.5

Adds support for passing additional arguments to Elasticsearch
constructor using `app_init` `kwargs`.

### Validate TLS certificate for connections to Elastsearch

By default Python elasticsearch client 1.x sets verify_certs to
False, which means it doesn't verify TLS certificates when connecting
to Elasticsearch over HTTPS and urllib3 prints an InsecureRequestWarning
on each request.

Setting `verify_certs=True` explicitly removes the warning and prevents
connections if the certificate doesn't validate.

### Update to base docker image 1.0.3

Moves awslogs agent logs to a file