### PR TITLE
Add aggregations endpoint

### DIFF
--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -1,6 +1,6 @@
 from flask import jsonify, url_for, request, abort
 from app.main import main
-from app.main.services.search_service import keyword_search, \
+from app.main.services.search_service import search_with_keywords_and_filters, aggregations_with_keywords_and_filters, \
     index, status_for_index, create_index, delete_index, \
     fetch_by_id, delete_by_id, create_alias
 from app.main.services.process_request_json import \
@@ -23,11 +23,24 @@ def root():
 
 @main.route('/<string:index_name>/<string:doc_type>/search', methods=['GET'])
 def search(index_name, doc_type):
-    result, status_code = keyword_search(index_name, doc_type, request.args)
+    result, status_code = search_with_keywords_and_filters(index_name, doc_type, request.args)
 
     if status_code == 200:
         return jsonify(meta=result['meta'],
                        services=result['services'],
+                       links=result['links']), status_code
+    else:
+        return api_response(result, status_code)
+
+
+@main.route('/<string:index_name>/<string:doc_type>/aggregations', methods=['GET'])
+def aggregations(index_name, doc_type):
+    result, status_code = aggregations_with_keywords_and_filters(index_name, doc_type, request.args,
+                                                                 request.args.getlist('aggregations'))
+
+    if status_code == 200:
+        return jsonify(meta=result['meta'],
+                       aggregations=result['aggregations'],
                        links=result['links']), status_code
     else:
         return api_response(result, status_code)

--- a/app/mapping.py
+++ b/app/mapping.py
@@ -16,4 +16,10 @@ TEXT_FIELDS = sorted(
     if not field.startswith('filter_')
 )
 
+AGGREGATABLE_FIELDS = sorted(
+    k
+    for k, v in SERVICES_MAPPING['mappings']['services']['properties'].items()
+    if v.get('fields', {}).get('raw', False)
+)
+
 TRANSFORM_FIELDS = SERVICES_MAPPING['mappings']['services']['_meta']['transformations']

--- a/mappings/services.json
+++ b/mappings/services.json
@@ -2,10 +2,10 @@
   "mappings": {
     "services": {
       "_meta": {
-        "version": "8.4.11",
+        "version": "8.6.1",
         "generated_from_framework": "g-cloud-9",
-        "generated_by": "/Users/georgelund/dev/digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2017-05-22T12:14:49.974655",
+        "generated_by": "/Users/samuelwilliams/git/digitalmarketplace-frameworks/scripts/generate-search-config.py",
+        "generated_time": "2017-06-12T06:12:12.322505",
         "transformations": [
           {
             "append_conditionally": {
@@ -635,7 +635,13 @@
         },
         "lot": {
           "type": "string",
-          "index": "not_analyzed"
+          "index": "not_analyzed",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
         },
         "lotName": {
           "type": "string",
@@ -741,7 +747,13 @@
           "index": "not_analyzed"
         },
         "serviceCategories": {
-          "type": "string"
+          "type": "string",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
         },
         "filter_serviceCategories": {
           "type": "string",


### PR DESCRIPTION
## Summary
This adds an endpoint to retrieve services aggregated by certain characters (e.g. lot and category) for use in G-Cloud search. The aggregated fields are detected based on the presence of a 'raw' multifield in the ES mapping; when we look at ES in more depth we should consider bringing the magic `filter_` fields under this same construct for the sake of simplicity.
Ripped out some real weirdness in the tests...

## Ticket
https://trello.com/c/5LRAkydD/481-show-number-of-services-within-category