### PR TITLE
Update to Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
+  - "3.6"
 install:
   - make requirements-dev
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:1.0.3
+FROM digitalmarketplace/base-api:2.0.2

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ run-app: virtualenv
 
 .PHONY: virtualenv
 virtualenv:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv venv || true
+	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && virtualenv -p python3 venv || true
 
 .PHONY: requirements
 requirements: virtualenv test-requirements requirements.txt


### PR DESCRIPTION
For this trello card: [https://trello.com/c/VH7lBFc5](https://trello.com/c/VH7lBFc5)

To upgrade the app to Python 3 we just need to pull in the Python 3
version of the base-api docker image. This is from version 2.0.0
onwards.

We also upgrade Travis to test with Python 3.6 to reflect the Python
version being used in the base image.

All unit tests are passing with 3.6, and the functional tests pass 
locally; master and jenkins branches.