### PR TITLE
Add default.nix for search-api (copied from dm-api)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-venv
+venv*
 .elasticbeanstalk/
 *.pyc
 __pycache__

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,45 @@
+argsOuter@{...}:
+let
+  # specifying args defaults in this slightly non-standard way to allow us to include the default values in `args`
+  args = rec {
+    pkgs = import <nixpkgs> {};
+    pythonPackages = pkgs.python36Packages;
+    forDev = true;
+    localOverridesPath = ./local.nix;
+  } // argsOuter;
+in (with args; {
+  digitalMarketplaceApiEnv = (pkgs.stdenv.mkDerivation rec {
+    name = "digitalmarketplace-search-api-env";
+    shortName = "dm-search-api";
+    buildInputs = [
+      pythonPackages.virtualenv
+      pkgs.libffi
+      pkgs.libyaml
+      # pip requires git to fetch some of its dependencies
+      pkgs.git
+      # for `cryptography`
+      pkgs.openssl
+    ] ++ pkgs.stdenv.lib.optionals forDev [
+      # exotic things possibly go here
+    ];
+
+    hardeningDisable = pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [ "format" ];
+
+    VIRTUALENV_ROOT = "venv${pythonPackages.python.pythonVersion}";
+    VIRTUAL_ENV_DISABLE_PROMPT = "1";
+    SOURCE_DATE_EPOCH = "315532800";
+
+    # if we don't have this, we get unicode troubles in a --pure nix-shell
+    LANG="en_GB.UTF-8";
+
+    shellHook = ''
+      export PS1="\[\e[0;36m\](nix-shell\[\e[0m\]:\[\e[0;36m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;36m\]\w\[\e[0m\]\$ "
+
+      if [ ! -e $VIRTUALENV_ROOT ]; then
+        ${pythonPackages.virtualenv}/bin/virtualenv $VIRTUALENV_ROOT
+      fi
+      source $VIRTUALENV_ROOT/bin/activate
+      make requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}
+    '';
+  }).overrideAttrs (if builtins.pathExists localOverridesPath then (import localOverridesPath args) else (x: x));
+})

--- a/local.example.nix
+++ b/local.example.nix
@@ -1,0 +1,22 @@
+# default.nix calls out to the file local.nix if it exists, expecting a function which it will call, applying first
+# the args passed to the original default.nix and then `oldAttrs`, the attrset originally applied to mkDerivation.
+#
+# the function should return an attrset altered to the local user's desires, as they would wish to be applied to
+# mkDerivation to produce the env
+
+args: oldAttrs: oldAttrs // {
+  # here we add some of our favourite packages to the environment which aren't necessarily to everyone's tastes
+  buildInputs = oldAttrs.buildInputs ++ [
+    args.pkgs.vim
+    args.pythonPackages.ipython
+  ];
+
+  shellHook =  oldAttrs.shellHook + ''
+    # PS1 can't be set as a normal derivation attr as it gets clobbered early on in the upstream shellHook script
+    export PS1="⚡$PS1⚡"
+
+    # inject some whimsy into our session - note here we access a package which we don't actually end up
+    # explicitly exposing to the final environment
+    ${args.pkgs.fortune}/bin/fortune
+  '';
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [pep8]
-exclude = ./venv
+exclude = ./venv*
 max-line-length = 120
 
 [tool:pytest]
-norecursedirs = venv
+norecursedirs = venv*
 
 [coverage:run]
 include = app/*


### PR DESCRIPTION
## Summary
Adds a `default.nix` file for the search-api, copied from the digitalmarketplace-api version. Updates .gitignore to ignore the venvs that nix generates.