### PR TITLE
Retrieve only service IDs for a search

### DIFF
--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -21,7 +21,11 @@ def construct_query(query_args, aggregations=[], page_size=100):
                 }
             }
         }
-    query["highlight"] = highlight_clause()
+
+    if 'idOnly' in query_args:
+        query['_source'] = ['id']
+    else:
+        query["highlight"] = highlight_clause()
 
     aggregations = set(aggregations)
     if aggregations:

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -123,6 +123,9 @@ def status_for_all_indexes():
 def core_search_and_aggregate(index_name, doc_type, query_args, search=False, aggregations=[]):
     try:
         page_size = int(current_app.config['DM_SEARCH_PAGE_SIZE'])
+        if 'idOnly' in query_args:
+            page_size *= int(current_app.config['DM_ID_ONLY_SEARCH_PAGE_SIZE_MULTIPLIER'])
+
         es_search_kwargs = {'search_type': 'count'} if aggregations and not search else {}
         res = es.search(
             index=index_name,

--- a/config.py
+++ b/config.py
@@ -16,6 +16,7 @@ class Config:
     DM_SEARCH_API_AUTH_TOKENS = None
 
     DM_SEARCH_PAGE_SIZE = 100
+    DM_ID_ONLY_SEARCH_PAGE_SIZE_MULTIPLIER = 10
     # Logging
     DM_LOG_LEVEL = 'DEBUG'
     DM_APP_NAME = 'search-api'


### PR DESCRIPTION
## Summary
When we lock a Direct Award project we need to retrieve the list of matching services for a given search. We only care about the ID of the service, not the content. Let's add a switch on search endpoint to only return matching service IDs. If we do this, increase page size as the data returned will be greatly reduced.

## Ticket
https://trello.com/c/gs2I3Cj2/676-end-your-search