### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: python
 python:
   - "3.6"
+env:
+  - ES_VERSION=1.7.6 ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
 install:
+  - wget ${ES_DOWNLOAD_URL}
+  - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
+  - ./elasticsearch-${ES_VERSION}/bin/elasticsearch > /dev/null &
   - make requirements-dev
 script:
   - PYTEST_ARGS='--cov=app --cov-report=term-missing' make test
 notifications:
   email: false
-
-services:
-  - elasticsearch
-
-before_script:
-  - sleep 10


### PR DESCRIPTION
## Summary
Update Travis config. Travis has moved from precise to trusty on Ubuntu and this has broken our tests that rely on Elasticsearch, so we need to manually pull in the right version of Elasticsearch and set that running.