### PR TITLE
Add new field (hash of service ID) to each indexed document

### DIFF
--- a/app/main/services/process_request_json.py
+++ b/app/main/services/process_request_json.py
@@ -1,3 +1,4 @@
+import hashlib
 import six
 
 import app.mapping
@@ -69,5 +70,9 @@ def convert_request_json_into_index_json(request_json):
                 )
             if field in mapping.text_fields_set:
                 index_json[field] = request_json[field]
+
+    if request_json.get('id'):
+        index_json[app.mapping.SERVICE_ID_HASH_FIELD_NAME] = \
+            hashlib.sha256(request_json['id'].encode('utf-8')).hexdigest()
 
     return index_json

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -126,7 +126,7 @@ def core_search_and_aggregate(index_name, doc_type, query_args, search=False, ag
         if 'idOnly' in query_args:
             page_size *= int(current_app.config['DM_ID_ONLY_SEARCH_PAGE_SIZE_MULTIPLIER'])
 
-        es_search_kwargs = {'search_type': 'count'} if aggregations and not search else {}
+        es_search_kwargs = {'search_type': 'count' if aggregations and not search else 'dfs_query_then_fetch'}
         res = es.search(
             index=index_name,
             doc_type=doc_type,

--- a/app/mapping.py
+++ b/app/mapping.py
@@ -2,6 +2,7 @@ from flask import json
 
 
 SERVICES_MAPPING_FILE_SPEC = "mappings/services.json"
+SERVICE_ID_HASH_FIELD_NAME = "service_id_hash"
 
 _services = None
 
@@ -18,7 +19,7 @@ class Mapping(object):
         self.text_fields = tuple(sorted(
             field
             for field in self.definition['mappings'][mapping_type]['properties'].keys()
-            if not field.startswith('filter_')
+            if not field.startswith('filter_') and field != SERVICE_ID_HASH_FIELD_NAME
         ))
         self.text_fields_set = frozenset(self.text_fields)
         self.aggregatable_fields = tuple(sorted(

--- a/mappings/services.json
+++ b/mappings/services.json
@@ -28,10 +28,10 @@
     "services": {
       "_meta": {
         "_": "DO NOT UPDATE BY HAND",
-        "version": "8.11.0",
+        "version": "8.17.0",
         "generated_from_framework": "g-cloud-9",
         "generated_by": "/Users/samuelwilliams/git/digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2017-07-28T13:32:52.823730",
+        "generated_time": "2017-10-05T07:36:24.346137",
         "transformations": [
           {
             "append_conditionally": {
@@ -660,6 +660,11 @@
         "id": {
           "type": "string",
           "index": "not_analyzed"
+        },
+        "service_id_hash": {
+          "type": "string",
+          "index": "not_analyzed",
+          "include_in_all": false
         },
         "lot": {
           "type": "string",

--- a/tests/app/services/test_process_request_json.py
+++ b/tests/app/services/test_process_request_json.py
@@ -1,5 +1,6 @@
 import pytest
 
+import app.mapping
 from app.main.services.process_request_json import \
     convert_request_json_into_index_json
 from nose.tools import assert_equal
@@ -208,3 +209,15 @@ def test_create_new_field_in_transformation(services_mapping):
     ]
 
     assert result["someField"] == ["foo"]
+
+
+def test_service_id_hash_added_if_id_present():
+    request = {
+        "id": "999999999",
+    }
+
+    result = convert_request_json_into_index_json(request)
+
+    assert result["id"] == "999999999"
+
+    assert app.mapping.SERVICE_ID_HASH_FIELD_NAME in result

--- a/tests/app/services/test_query_builder.py
+++ b/tests/app/services/test_query_builder.py
@@ -3,6 +3,7 @@ from nose.tools import (
     assert_false, assert_true
 )
 import pytest
+import app.mapping
 from app.main.services.query_builder import construct_query, is_filtered
 from app.main.services.query_builder import (
     field_is_or_filter, field_filters,
@@ -205,6 +206,17 @@ def test_highlight_block_sets_encoder_to_html():
         build_query_params(keywords="some keywords"))
 
     assert_equal(query["highlight"]["encoder"], "html")
+
+
+def test_service_id_hash_not_in_searched_fields():
+    query = construct_query(build_query_params(keywords="some keywords"))
+
+    assert app.mapping.SERVICE_ID_HASH_FIELD_NAME not in query['query']['simple_query_string']['fields']
+
+    query = construct_query(
+        build_query_params(filters={'serviceTypes': ["serviceType1"]}))
+
+    assert app.mapping.SERVICE_ID_HASH_FIELD_NAME not in query['highlight']['fields']
 
 
 @pytest.mark.parametrize('example, expected', (

--- a/tests/fixtures/mappings/services.json
+++ b/tests/fixtures/mappings/services.json
@@ -47,6 +47,11 @@
           "type": "string",
           "index": "not_analyzed"
         },
+        "service_id_hash": {
+          "type": "string",
+          "index": "not_analyzed",
+          "include_in_all": false
+        },
         "lot": {
           "type": "string",
           "index": "not_analyzed",


### PR DESCRIPTION
## Summary
Add a new field to each document (a hash of the serviceId) that will allow tiebreaking results that have the same score to give random (but consistent) ordering. We will not actually _use_ the tiebreaker field yet as we need to re-index all stages with the new mapping before we can start to utilise it in a follow-up PR.

## Ticket
https://trello.com/c/RyS8rrIc/20-search-ordering-bug-small