### PR TITLE
Order results by score and tiebreaker

### DIFF
--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -27,6 +27,8 @@ def construct_query(query_args, aggregations=[], page_size=100):
     else:
         query["highlight"] = highlight_clause()
 
+    query['sort'] = ['_score', {app.mapping.SERVICE_ID_HASH_FIELD_NAME: 'desc'}]
+
     aggregations = set(aggregations)
     if aggregations:
         missing_aggregations = aggregations.difference(app.mapping.get_services_mapping().aggregatable_fields)

--- a/tests/app/services/test_query_builder.py
+++ b/tests/app/services/test_query_builder.py
@@ -219,6 +219,11 @@ def test_service_id_hash_not_in_searched_fields():
     assert app.mapping.SERVICE_ID_HASH_FIELD_NAME not in query['highlight']['fields']
 
 
+def test_sort_results_by_score_and_service_id_hash():
+    query = construct_query(build_query_params(keywords="some keywords"))
+    assert query['sort'] == ['_score', {app.mapping.SERVICE_ID_HASH_FIELD_NAME: 'desc'}]
+
+
 @pytest.mark.parametrize('example, expected', (
     ("id", True),
     ("lot", True),


### PR DESCRIPTION
## Summary
Follow-up PR to https://github.com/alphagov/digitalmarketplace-search-api/pull/107 which starts using the added field to sort results. We order by term `_score` first, and if those are equal, tiebreak using the hash to give consistent result ordering.

This PR only consists of the single commit but sits on top of PR 107 above, so the change view contains more than this actually implements. Look here for the commit changes: https://github.com/alphagov/digitalmarketplace-search-api/pull/108/commits/7e54a3380eb4b32c61baf0656b025cb3b9f886b8

## Ticket
https://trello.com/c/RyS8rrIc/20-search-ordering-bug-small