### PR TITLE
Add milliseconds to application log time format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:2.0.2
+FROM digitalmarketplace/base-api:2.0.5

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -4,7 +4,7 @@
 Flask==0.10.1
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.0#egg=digitalmarketplace-utils==27.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
 
 # Elasticsearch 1.0
 elasticsearch>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,28 +5,28 @@
 Flask==0.10.1
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@27.2.0#egg=digitalmarketplace-utils==27.2.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
 
 # Elasticsearch 1.0
 elasticsearch>=1.0.0,<2.0.0
 Flask-Elasticsearch==0.2.5
 
 ## The following requirements were added by pip freeze:
-asn1crypto==0.22.0
+asn1crypto==0.23.0
 boto3==1.4.4
-botocore==1.5.82
-certifi==2017.4.17
-cffi==1.10.0
+botocore==1.5.95
+certifi==2017.7.27.1
+cffi==1.11.2
 chardet==3.0.4
 contextlib2==0.4.0
 cryptography==1.9
 docopt==0.4.0
-docutils==0.13.1
+docutils==0.14
 Flask-FeatureFlags==0.6
 Flask-Script==2.0.5
 Flask-WTF==0.12
 future==0.16.0
-idna==2.5
+idna==2.6
 inflection==0.2.1
 itsdangerous==0.24
 Jinja2==2.9.6
@@ -36,16 +36,17 @@ mandrill==1.0.57
 MarkupSafe==1.0
 monotonic==0.3
 notifications-python-client==4.1.0
+odfpy==1.3.3
 pycparser==2.18
-PyJWT==1.5.2
+PyJWT==1.5.3
 python-dateutil==2.6.1
 pytz==2015.4
 PyYAML==3.11
-requests==2.18.1
-s3transfer==0.1.10
+requests==2.18.4
+s3transfer==0.1.11
 six==1.9.0
 unicodecsv==0.14.1
-urllib3==1.21.1
+urllib3==1.22
 Werkzeug==0.12.2
 workdays==1.4
 WTForms==2.1


### PR DESCRIPTION
Upgrades dmutils and base Docker image to add milliseconds to app logs shipped to CloudWatch.

This allows us to maintain the order of the log messages written by an application instance in Kibana.