### PR TITLE
Catch 'N/A' connection error and 500

### DIFF
--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -118,10 +118,20 @@ def delete_service(index_name, doc_type, service_id):
 
 
 def api_response(data, status_code, key='message'):
-    if status_code // 100 == 2:
-        return jsonify({key: data}), status_code
-    else:
-        return jsonify(error=data), status_code
+    """Handle error codes.
+
+    See http://elasticsearch-py.readthedocs.io/en/master/exceptions.html#elasticsearch.TransportError.status_code for
+    an explaination of 'N/A' status code. elasticsearch-py client returns 'N/A' as status code if ES server cannot be
+    reached
+    """
+    try:
+        if status_code // 100 == 2:
+            return jsonify({key: data}), status_code
+    except TypeError as e:
+        if status_code == 'N/A':
+            return jsonify(error=str(data)), 500
+        raise e
+    return jsonify(error=data), status_code
 
 
 def check_json_from_request(request):


### PR DESCRIPTION
This fixes the uncaught application exception: 
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "./app/main/views/search.py", line 56, in index_document
    return api_response(result, status_code)
  File "./app/main/views/search.py", line 121, in api_response
    if status_code // 100 == 2:
TypeError: unsupported operand type(s) for //: 'str' and 'int'
```
When the `search-api` returns a connection error attempting connect to PaaS ES.

Log example:
https://kibana.logit.io/app/kibana#/doc/logs-*/logs-2017.10.31/production-search-api-application?id=33661141855789393415770837087925560466251432081516265473&_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-24h,mode:quick,to:now))

Reproduced the error locally by setting 
```    
ELASTICSEARCH_HOST = 'localhost:920'
```
then:
```

In [1]: from app.main.services.search_service import index

In [2]: x=index('applicationjson','application/json',{},'application/json')
2017-10-31T13:45:10 search-api app ERROR 0b93f71f-caf4-4946-b9c9-6e534c3c5801 "Failed to index the document application/json: <urllib3.connection.HTTPConnection object at 0x106ec0588>: Failed to establish a new connection: [Errno 61] C
onnection refused" [in digitalmarketplace-search-api/app/main/services/search_service.py:101]
```