### PR TITLE
100 remove services hard coding

### DIFF
--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -33,13 +33,17 @@ def aggregations(index_name, doc_type):
         return api_response(result, status_code)
 
 
-@main.route('/<string:index_name>/<string:doc_type>/<string:service_id>',
+@main.route('/<string:index_name>/<string:doc_type>/<string:document_id>',
             methods=['PUT'])
-def index_document(index_name, doc_type, service_id):
-    json_payload = get_json_from_request('service')
+def index_document(index_name, doc_type, document_id):
+    payload = check_json_from_request(request)
+    json_payload = payload.get('document') or payload.get('service')  # fallback to 'service' for backward-compat.
+    if json_payload is None:
+        abort(400, "Invalid JSON must have 'document' key.")
+
     mapping = app.mapping.get_mapping(index_name, doc_type)
     index_json = convert_request_json_into_index_json(mapping, json_payload)
-    result, status_code = index(index_name, doc_type, index_json, service_id)
+    result, status_code = index(index_name, doc_type, index_json, document_id)
 
     return api_response(result, status_code)
 

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -78,7 +78,7 @@ def setup_authorization(app):
         HTTP_AUTHORIZATION='Bearer {}'.format(app.config['DM_SEARCH_API_AUTH_TOKENS']))
 
 
-def default_service(**kwargs):
+def make_standard_service(**kwargs):
     service = {
         "id": "id",
         "lot": "LoT",
@@ -96,8 +96,13 @@ def default_service(**kwargs):
     service.update(kwargs)
 
     return {
-        "service": service
+        "document": service
     }
+
+
+def make_search_api_url(data, type_name='services'):
+    # currently, data may contain either "document" or "service" (as a backward compatibility shim)
+    return '/index-to-create/{}/{}'.format(type_name, str(data.get('document', data.get('service'))['id']))
 
 
 def assert_response_status(response, expected_status):

--- a/tests/app/views/test_search_queries.py
+++ b/tests/app/views/test_search_queries.py
@@ -4,8 +4,7 @@ from nose.tools import assert_equal, ok_
 import pytest
 
 from app import create_app
-from ..helpers import setup_authorization
-from ..helpers import default_service
+from ..helpers import setup_authorization, make_standard_service
 
 
 # Helpers for 'result_fields_check'
@@ -195,7 +194,7 @@ def dummy_services(services_mapping_definition):
         services = list(create_services(120))
         for service in services:
             test_client.put(
-                '/index-to-create/services/%s' % service["service"]["id"],
+                '/index-to-create/services/%s' % service["document"]["id"],
                 data=json.dumps(service), content_type='application/json'
             )
             search_service.refresh('index-to-create')
@@ -207,7 +206,7 @@ def dummy_services(services_mapping_definition):
 
 def create_services(number_of_services):
     for i in range(number_of_services):
-        yield default_service(
+        yield make_standard_service(
             id=str(i),
             serviceName="Service {}".format(i),
             phoneSupport=bool(i % 2),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
 
+
 import pytest
 import os
 import mock
 import json
 
 import app.mapping
+from tests.app.helpers import make_standard_service
 
 
 with open(os.path.join(os.path.dirname(__file__), 'fixtures/mappings/services.json')) as f:
@@ -25,3 +27,17 @@ def services_mapping_definition():
     with mock.patch('app.mapping.load_mapping_definition') as mock_definition_loader:
         mock_definition_loader.return_value = _services_mapping_definition
         yield mock_definition_loader.return_value
+
+
+@pytest.fixture(scope="function", params=['service', 'document'])
+def default_service(request):
+    """
+    A fixture for a service such as might be indexed in the Search API. For now, parameterized so that we can test
+    both the old style where the structure had a top-level dictionary key hard-coded to 'service', and the new
+    style where we just look for a key 'document', which could be a DOS brief or a G-Cloud service or anything else.
+    :return: dict
+    """
+    service = make_standard_service()
+    if request.param != 'document':
+        service = {request.param: service['document']}
+    return service


### PR DESCRIPTION
We're trying to remove all mention of 'services' from the Search API. This is one step along the way.

All of our tests are still very much about services rather than anything more generic, but if they exercise the code paths that's okay. Many of the tests did have to change though, as they had hard-coded knowledge of the one string we are changing in this PR (sad face).

https://trello.com/c/5oIKvS1s/100-search-service-for-briefs-plus-indexing-script