### PR TITLE
Wrong doctype 400

### DIFF
--- a/app/mapping.py
+++ b/app/mapping.py
@@ -62,14 +62,19 @@ class Mapping(object):
 
 
 def get_mapping(index_name, document_type):
-    # es.indices.get_mapping has a key for the index name, regardless of any alias we may be going via, so rather than
-    # use index_name, we access the one and only value in the dictionary using next(iter).
-    mapping_data = next(iter(es.indices.get_mapping(index=index_name, doc_type=document_type).values()))
+    try:
+        # es.indices.get_mapping has a key for the index name, regardless of any alias we may be going via, so rather
+        # than use index_name, we access the one and only value in the dictionary using next(iter).
+        mapping_data = next(iter(es.indices.get_mapping(index=index_name, doc_type=document_type).values()))
 
-    # In ES <=5, there may be multiple mapping types per document type (kind-of) - this is confusing, but going away,
-    # see <https://www.elastic.co/guide/en/elasticsearch/reference/5.6/removal-of-types.html>. For us, document_type
-    # === mapping_type, and there will be only one per index.
-    return Mapping(mapping_data, mapping_type=document_type)
+        # In ES <=5, there may be multiple mapping types per document type (kind-of) - this is confusing, but going
+        # away, see <https://www.elastic.co/guide/en/elasticsearch/reference/5.6/removal-of-types.html>. For us,
+        # document_type === mapping_type, and there will be only one per index.
+        return Mapping(mapping_data, mapping_type=document_type)
+
+    except StopIteration:
+        raise MappingNotFound("Document type '{}' is not valid in index '{}' - no mapping found.".format(
+            document_type, index_name))
 
 
 def load_mapping_definition(mapping_name):

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -250,6 +250,14 @@ class TestIndexingDocuments(BaseApplicationTestWithIndex):
 
         assert_response_status(response, 200)
 
+    def test_should_raise_400_on_bad_doc_type(self, default_service):
+        response = self.client.put(
+            make_search_api_url(default_service, type_name='some-bad-type'),
+            data=json.dumps(default_service),
+            content_type='application/json')
+
+        assert_response_status(response, 400)
+
 
 @pytest.mark.usefixtures("services_mapping_definition")
 class TestSearchEndpoint(BaseApplicationTestWithIndex):


### PR DESCRIPTION
Produce comprehensible error when client attempts to use wrong doctype.
 - when we can't find the mapping, a 400 will do.

https://trello.com/c/5oIKvS1s/100-search-service-for-briefs-plus-indexing-script