### PR TITLE
Add `filter_status` to briefs mapping and return documents instead of services 

### DIFF
--- a/app/main/services/response_formatters.py
+++ b/app/main/services/response_formatters.py
@@ -43,20 +43,20 @@ def _convert_es_result(mapping, es_result):
 
 
 def convert_es_results(mapping, results, query_args):
-    services = []
+    documents = []
 
-    for service in results["hits"]["hits"]:
+    for document in results["hits"]["hits"]:
         if 'idOnly' in query_args:
-            services.append({"id": service["_id"]})
+            documents.append({"id": document["_id"]})
         else:
-            # populate result from service["_source"] object
-            result = _convert_es_result(mapping, service["_source"])
+            # populate result from document["_source"] object
+            result = _convert_es_result(mapping, document["_source"])
 
-            if "highlight" in service:
+            if "highlight" in document:
                 # perform the same conversion for any highlight terms
-                result["highlight"] = _convert_es_result(mapping, service["highlight"])
+                result["highlight"] = _convert_es_result(mapping, document["highlight"])
 
-            services.append(result)
+            documents.append(result)
 
     return {
         "meta": {
@@ -64,7 +64,7 @@ def convert_es_results(mapping, results, query_args):
             "total": results["hits"]["total"],
             "took": results["took"],
         },
-        "services": services,
+        "documents": documents,
     }
 
 

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -145,7 +145,7 @@ def core_search_and_aggregate(index_name, doc_type, query_args, search=False, ag
 
         response = {
             "meta": results['meta'],
-            "services": results['services'],
+            "documents": results['documents'],
             "links": generate_pagination_links(
                 query_args, results['meta']['total'],
                 page_size, url_for_search

--- a/app/main/views/search.py
+++ b/app/main/views/search.py
@@ -12,7 +12,7 @@ def search(index_name, doc_type):
 
     if status_code == 200:
         return jsonify(meta=result['meta'],
-                       services=result['services'],
+                       documents=result["documents"],
                        links=result['links']), status_code
     else:
         return api_response(result, status_code)

--- a/tests/app/services/test_response_formatters.py
+++ b/tests/app/services/test_response_formatters.py
@@ -32,14 +32,14 @@ def test_should_build_search_response_from_es_response(services_mapping):
     assert_equal(res["meta"]["query"]["q"], "keywords")
     assert_equal(res["meta"]["total"], 628)
     assert_equal(res["meta"]["took"], 69)
-    assert_equal(len(res["services"]), 10)
+    assert_equal(len(res["documents"]), 10)
 
-    assert_equal(res["services"][0]["id"], "5390159512076288")
-    assert_equal(res["services"][0]["lot"], "SaaS")
-    assert_equal(res["services"][0]["frameworkName"], "G-Cloud 6")
-    assert_equal(res["services"][0]["supplierName"], "Supplier Name")
-    assert_equal(res["services"][0]["serviceName"], "Email Verification")
-    assert_equal(res["services"][0]["serviceTypes"], [
+    assert_equal(res["documents"][0]["id"], "5390159512076288")
+    assert_equal(res["documents"][0]["lot"], "SaaS")
+    assert_equal(res["documents"][0]["frameworkName"], "G-Cloud 6")
+    assert_equal(res["documents"][0]["supplierName"], "Supplier Name")
+    assert_equal(res["documents"][0]["serviceName"], "Email Verification")
+    assert_equal(res["documents"][0]["serviceTypes"], [
         "Data management"
     ])
 
@@ -47,15 +47,15 @@ def test_should_build_search_response_from_es_response(services_mapping):
 def test_should_build_highlights_es_response(services_mapping):
     res = convert_es_results(services_mapping, SEARCH_RESULTS_JSON, {"q": "keywords"})
     assert_equal(
-        res["services"][0]["highlight"]["serviceName"],
+        res["documents"][0]["highlight"]["serviceName"],
         ["Email Verification"])
-    assert_equal(res["services"][0]["highlight"]["serviceFeatures"], [
+    assert_equal(res["documents"][0]["highlight"]["serviceFeatures"], [
         "Verify email addresses at the point of entry",
         "Validate email address format",
         "Live email account",
         "Safe to email"
     ])
-    assert_equal(res["services"][0]["highlight"]["serviceBenefits"], [
+    assert_equal(res["documents"][0]["highlight"]["serviceBenefits"], [
         "Increase email deliverability"
     ])
 
@@ -64,7 +64,7 @@ def test_should_not_include_highlights_if_not_in_es_results(services_mapping):
     copy = SEARCH_RESULTS_JSON
     del copy["hits"]["hits"][0]["highlight"]
     res = convert_es_results(services_mapping, copy, {"category": "some catergory"})
-    assert_equal("highlight" in res["services"][0], False)
+    assert_equal("highlight" in res["documents"][0], False)
 
 
 def test_should_build_status_response_from_es_response():

--- a/tests/app/services/test_response_formatters.py
+++ b/tests/app/services/test_response_formatters.py
@@ -1,4 +1,3 @@
-from nose.tools import assert_equal
 from flask import json
 
 import pytest
@@ -23,67 +22,61 @@ with open("example_es_responses/search_results.json") as search_results:
 def test_should_build_query_block_in_response(services_mapping):
     res = convert_es_results(services_mapping, SEARCH_RESULTS_JSON,
                              {"q": "keywords", "category": "some catergory"})
-    assert_equal(res["meta"]["query"]["q"], "keywords")
-    assert_equal(res["meta"]["query"]["category"], "some catergory")
+    assert res["meta"]["query"]["q"] == "keywords"
+    assert res["meta"]["query"]["category"] == "some catergory"
 
 
 def test_should_build_search_response_from_es_response(services_mapping):
     res = convert_es_results(services_mapping, SEARCH_RESULTS_JSON, {"q": "keywords"})
-    assert_equal(res["meta"]["query"]["q"], "keywords")
-    assert_equal(res["meta"]["total"], 628)
-    assert_equal(res["meta"]["took"], 69)
-    assert_equal(len(res["documents"]), 10)
+    assert res["meta"]["query"]["q"] == "keywords"
+    assert res["meta"]["total"] == 628
+    assert res["meta"]["took"] == 69
+    assert len(res["documents"]) == 10
 
-    assert_equal(res["documents"][0]["id"], "5390159512076288")
-    assert_equal(res["documents"][0]["lot"], "SaaS")
-    assert_equal(res["documents"][0]["frameworkName"], "G-Cloud 6")
-    assert_equal(res["documents"][0]["supplierName"], "Supplier Name")
-    assert_equal(res["documents"][0]["serviceName"], "Email Verification")
-    assert_equal(res["documents"][0]["serviceTypes"], [
-        "Data management"
-    ])
+    assert res["documents"][0]["id"] == "5390159512076288"
+    assert res["documents"][0]["lot"] == "SaaS"
+    assert res["documents"][0]["frameworkName"] == "G-Cloud 6"
+    assert res["documents"][0]["supplierName"] == "Supplier Name"
+    assert res["documents"][0]["serviceName"] == "Email Verification"
+    assert res["documents"][0]["serviceTypes"] == ["Data management"]
 
 
 def test_should_build_highlights_es_response(services_mapping):
     res = convert_es_results(services_mapping, SEARCH_RESULTS_JSON, {"q": "keywords"})
-    assert_equal(
-        res["documents"][0]["highlight"]["serviceName"],
-        ["Email Verification"])
-    assert_equal(res["documents"][0]["highlight"]["serviceFeatures"], [
+    assert res["documents"][0]["highlight"]["serviceName"] == ["Email Verification"]
+    assert res["documents"][0]["highlight"]["serviceFeatures"] == [
         "Verify email addresses at the point of entry",
         "Validate email address format",
         "Live email account",
         "Safe to email"
-    ])
-    assert_equal(res["documents"][0]["highlight"]["serviceBenefits"], [
-        "Increase email deliverability"
-    ])
+    ]
+    assert res["documents"][0]["highlight"]["serviceBenefits"] == ["Increase email deliverability"]
 
 
 def test_should_not_include_highlights_if_not_in_es_results(services_mapping):
     copy = SEARCH_RESULTS_JSON
     del copy["hits"]["hits"][0]["highlight"]
     res = convert_es_results(services_mapping, copy, {"category": "some catergory"})
-    assert_equal("highlight" in res["documents"][0], False)
+    assert "highlight" not in res["documents"][0]
 
 
 def test_should_build_status_response_from_es_response():
     res = convert_es_status("g-cloud-9", STATS_JSON, INDEX_INFO_JSON)
-    assert_equal(res, {
+    assert res == {
         "num_docs": 19676,
         "primary_size": "52mb",
         "mapping_version": "9.0.0",
         "aliases": ["galias"],
-    })
+    }
 
 
 def test_should_build_status_response_from_es_response_with_empty_index():
     stats_json_with_no_docs = dict(STATS_JSON)
     del stats_json_with_no_docs["indices"]["g-cloud-9"]["primaries"]["docs"]
     res = convert_es_status("g-cloud-9", stats_json_with_no_docs)
-    assert_equal(res, {
+    assert res == {
         "aliases": [],
         "mapping_version": None,
         "num_docs": None,
         "primary_size": "52mb",
-    })
+    }

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -80,7 +80,7 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
             assert_equal(
                 get_json_from_response(response)["meta"]["total"], 10)
             assert_equal(
-                len(get_json_from_response(response)["services"]), 5)
+                len(get_json_from_response(response)["documents"]), 5)
 
     def test_should_get_pagination_links(self):
         with self.app.app_context():
@@ -103,7 +103,7 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
             assert_equal(
                 get_json_from_response(response)["meta"]["total"], 10)
             assert_equal(
-                len(get_json_from_response(response)["services"]), 5)
+                len(get_json_from_response(response)["documents"]), 5)
 
     def test_should_get_no_services_on_out_of_bounds_from(self):
         with self.app.app_context():
@@ -114,7 +114,7 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
             assert_equal(
                 get_json_from_response(response)["meta"]["total"], 10)
             assert_equal(
-                len(get_json_from_response(response)["services"]), 0)
+                len(get_json_from_response(response)["documents"]), 0)
 
     def test_should_get_400_response__on_negative_page(self):
         with self.app.app_context():
@@ -144,7 +144,7 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
         assert_response_status(response, 200)
         search_results = get_json_from_response(
             response
-        )["services"]
+        )["documents"]
         assert_equal(
             search_results[0]["highlight"]["serviceSummary"][0],
             highlighted_summary
@@ -160,7 +160,7 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
             query_string='q=storing'
         )
         assert_response_status(response, 200)
-        search_results = get_json_from_response(response)["services"]
+        search_results = get_json_from_response(response)["documents"]
         assert_equal(
             search_results[0]["highlight"]["serviceSummary"][0],
             "accessing, <mark class='search-result-highlighted-text'>" +
@@ -178,7 +178,7 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
             query_string='q=oY'
         )
         assert_response_status(response, 200)
-        search_results = get_json_from_response(response)["services"]
+        search_results = get_json_from_response(response)["documents"]
         assert_equal(
             search_results[0]["highlight"]["serviceSummary"][0],
             "Oh &lt;script&gt;alert(&quot;Yo&quot;);&lt;&#x2F;script&gt;"
@@ -200,7 +200,7 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
         )
         assert_response_status(response, 200)
 
-        search_results = get_json_from_response(response)["services"]
+        search_results = get_json_from_response(response)["documents"]
         # Get the first with a matching value from a list
         search_result = next((s for s in search_results if s['lot'] == 'TaaS'), None)
         assert_true(490 < len(search_result["highlight"]["serviceSummary"][0]) < 510)
@@ -221,7 +221,7 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
             response_json = get_json_from_response(response)
 
             assert_response_status(response, 200)
-            assert_equal(len(response_json['services']), expected_count)
+            assert_equal(len(response_json['documents']), expected_count)
 
     def test_only_ids_returned_for_id_only_request(self):
         with self.app.app_context():
@@ -230,7 +230,7 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
             response_json = get_json_from_response(response)
 
             assert_response_status(response, 200)
-            assert_equal(set(response_json['services'][0].keys()), {'id'})
+            assert_equal(set(response_json['documents'][0].keys()), {'id'})
 
 
 class TestFetchById(BaseApplicationTestWithIndex):
@@ -337,7 +337,7 @@ class TestSearchResultsOrdering(BaseApplicationTestWithIndex):
             assert_response_status(response, 200)
             assert_equal(get_json_from_response(response)["meta"]["total"], 10)
 
-        ordered_service_ids = [service['id'] for service in json.loads(response.get_data(as_text=True))['services']]
+        ordered_service_ids = [service['id'] for service in json.loads(response.get_data(as_text=True))['documents']]
         assert ordered_service_ids == ['5', '6', '2', '7', '1', '0', '3', '4', '8', '9']  # fixture for sha256 ordering
 
 

--- a/tests/app/views/test_search_queries.py
+++ b/tests/app/views/test_search_queries.py
@@ -31,149 +31,148 @@ def test_single_filter_queries(query, expected_result_count, match_fields):
 
 
 def test_basic_aggregations():
-    yield check_aggregations_query, '', 120, {'PaaS': (30).__eq__, 'SaaS': (30).__eq__, 'IaaS': (30).__eq__,
-                                              'SCS': (30).__eq__}
-    yield check_aggregations_query, 'filter_lot=SaaS', 30, {'SaaS': (30).__eq__}
-    yield check_aggregations_query, 'filter_minimumContractPeriod=Hour,Day', 80, {'PaaS': (20).__eq__,
-                                                                                  'SaaS': (20).__eq__,
-                                                                                  'IaaS': (20).__eq__,
-                                                                                  'SCS': (20).__eq__}
-    yield check_aggregations_query, 'filter_lot=SaaS&filter_minimumContractPeriod=Hour,Day', 20, {'SaaS': (20).__eq__}
+    check_aggregations_query(
+        '',
+        120,
+        {'PaaS': (30).__eq__, 'SaaS': (30).__eq__, 'IaaS': (30).__eq__, 'SCS': (30).__eq__}
+    )
+    check_aggregations_query('filter_lot=SaaS', 30, {'SaaS': (30).__eq__})
+    check_aggregations_query(
+        'filter_minimumContractPeriod=Hour,Day',
+        80,
+        {'PaaS': (20).__eq__, 'SaaS': (20).__eq__, 'IaaS': (20).__eq__, 'SCS': (20).__eq__}
+    )
+    check_aggregations_query('filter_lot=SaaS&filter_minimumContractPeriod=Hour,Day', 20, {'SaaS': (20).__eq__})
 
 
 def test_or_filters():
-    yield (check_query, 'filter_lot=SaaS,PaaS',
-           60, {'lot': ['SaaS', 'PaaS'].__contains__})
-    yield check_query, 'filter_minimumContractPeriod=Hour,Day', 80, {}
-    yield (check_query, 'filter_datacentreTier=tia-942 tier 1,tia-942 tier 2',
-           120, {})
-    yield (check_query, 'filter_datacentreTier=tia-942 tier 3,tia-942 tier 2',
-           0, {})
-    yield (check_query,
-           'filter_minimumContractPeriod=Hour,Day&filter_datacentreTier=tia-942 tier 3,tia-942 tier 2',
-           0, {})
+    check_query('filter_lot=SaaS,PaaS', 60, {'lot': ['SaaS', 'PaaS'].__contains__})
+    check_query('filter_minimumContractPeriod=Hour,Day', 80, {})
+    check_query('filter_datacentreTier=tia-942 tier 1,tia-942 tier 2', 120, {})
+    check_query('filter_datacentreTier=tia-942 tier 3,tia-942 tier 2', 0, {})
+    check_query('filter_minimumContractPeriod=Hour,Day&filter_datacentreTier=tia-942 tier 3,tia-942 tier 2', 0, {})
 
 
 def test_and_filters():
-    yield (check_query,
-           'filter_serviceTypes=Planning&filter_serviceTypes=Testing',
-           24, {'serviceTypes': ['Planning', 'Testing'].__eq__})
+    check_query(
+        'filter_serviceTypes=Planning&filter_serviceTypes=Testing',
+        24, {'serviceTypes': ['Planning', 'Testing'].__eq__}
+    )
 
-    yield (check_query,
-           'filter_serviceTypes=Planning&filter_serviceTypes=Implementation',
-           0, {})
+    check_query(
+        'filter_serviceTypes=Planning&filter_serviceTypes=Implementation',
+        0, {}
+    )
 
-    yield check_query, 'filter_lot=SaaS&filter_lot=PaaS', 0, {}
+    check_query('filter_lot=SaaS&filter_lot=PaaS', 0, {})
 
 
 def test_filter_combinations():
-    yield (check_query,
-           'filter_minimumContractPeriod=Hour&filter_phoneSupport=false',
-           20, {'id': even})
+    check_query(
+        'filter_minimumContractPeriod=Hour&filter_phoneSupport=false',
+        20, {'id': even}
+    )
 
-    yield (check_query,
-           'filter_minimumContractPeriod=Hour,Day&filter_phoneSupport=false',
-           40, {'id': even})
+    check_query(
+        'filter_minimumContractPeriod=Hour,Day&filter_phoneSupport=false',
+        40, {'id': even}
+    )
 
-    yield (check_query,
-           'filter_minimumContractPeriod=Hour,Day&filter_phoneSupport=false&filter_lot=SaaS',
-           20, {'id': even})
+    check_query(
+        'filter_minimumContractPeriod=Hour,Day&filter_phoneSupport=false&filter_lot=SaaS',
+        20, {'id': even}
+    )
 
-    yield (check_query,
-           'filter_minimumContractPeriod=Hour&filter_lot=SaaS',
-           10, {'lot': 'SaaS'.__eq__})
+    check_query(
+        'filter_minimumContractPeriod=Hour&filter_lot=SaaS',
+        10, {'lot': 'SaaS'.__eq__}
+    )
 
-    yield (check_query,
-           'q=12&filter_minimumContractPeriod=Hour&filter_lot=SaaS',
-           1, {'lot': 'SaaS'.__eq__, 'id': '12'.__eq__})
+    check_query(
+        'q=12&filter_minimumContractPeriod=Hour&filter_lot=SaaS',
+        1, {'lot': 'SaaS'.__eq__, 'id': '12'.__eq__}
+    )
 
-    yield (check_query,
-           'q=12&filter_minimumContractPeriod=Hour&filter_lot=PaaS', 0, {})
+    check_query(
+        'q=12&filter_minimumContractPeriod=Hour&filter_lot=PaaS', 0, {}
+    )
 
 
 def test_special_characters():
     # Elasticserch reserved characters:
     #   + - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /
 
-    yield (check_query, 'q=Service%3D1', 1, {})  # =
-    yield (check_query, 'q=Service%211', 1, {})  # !
-    yield (check_query, 'q=Service%5E1', 1, {})  # ^
-    yield (check_query, 'q=Service%7E1', 1, {})  # ~
-    yield (check_query, 'q=Service%3F1', 1, {})  # ?
-    yield (check_query, 'q=Service%3A1', 1, {})  # :
-    yield (check_query, 'q=Service%5C 1', 1, {})  # \
-    yield (check_query, 'q=Service%2F1', 1, {})  # /
-    yield (check_query, 'q=Service%26%261', 1, {})  # &&
-    yield (check_query, 'q=Service 1*', 1, {})
+    check_query('q=Service%3D1', 1, {})  # =
+    check_query('q=Service%211', 1, {})  # !
+    check_query('q=Service%5E1', 1, {})  # ^
+    check_query('q=Service%7E1', 1, {})  # ~
+    check_query('q=Service%3F1', 1, {})  # ?
+    check_query('q=Service%3A1', 1, {})  # :
+    check_query('q=Service%5C 1', 1, {})  # \
+    check_query('q=Service%2F1', 1, {})  # /
+    check_query('q=Service%26%261', 1, {})  # &&
+    check_query('q=Service 1*', 1, {})
 
-    yield (check_query, 'q=Service>1', 1, {})
-    yield (check_query, 'q=Service<1', 1, {})
+    check_query('q=Service>1', 1, {})
+    check_query('q=Service<1', 1, {})
 
-    yield (check_query, 'q=Service(1', 1, {})
-    yield (check_query, 'q=Service)1', 1, {})
+    check_query('q=Service(1', 1, {})
+    check_query('q=Service)1', 1, {})
 
-    yield (check_query, 'q=Service{1', 1, {})
-    yield (check_query, 'q=Service}1', 1, {})
+    check_query('q=Service{1', 1, {})
+    check_query('q=Service}1', 1, {})
 
-    yield (check_query, 'q=Service[1', 1, {})
-    yield (check_query, 'q=Service]1', 1, {})
+    check_query('q=Service[1', 1, {})
+    check_query('q=Service]1', 1, {})
 
-    yield (check_query, 'q=id%3A1', 0, {})
+    check_query('q=id%3A1', 0, {})
 
 
 def test_basic_keyword_search():
-    yield (check_query,
-           'q=Service',
-           120, {})
+    check_query('q=Service', 120, {})
 
 
 def test_and_keyword_search():
-    yield (check_query,
-           'q=Service 1',
-           1, {})
+    check_query('q=Service 1', 1, {})
 
-    yield (check_query, 'q=Service 1 2 3', 0, {})
+    check_query('q=Service 1 2 3', 0, {})
 
-    yield (check_query, 'q=+Service +1', 1, {})
-    yield (check_query, 'q=Service %26100', 1, {})
-    yield (check_query, 'q=Service %26 100', 0, {})
-    yield (check_query, 'q=Service %26%26100', 1, {})
-    yield (check_query, 'q=Service %26%26 100', 0, {})
+    check_query('q=+Service +1', 1, {})
+    check_query('q=Service %26100', 1, {})
+    check_query('q=Service %26 100', 0, {})
+    check_query('q=Service %26%26100', 1, {})
+    check_query('q=Service %26%26 100', 0, {})
 
 
 def test_phrase_keyword_search():
-    yield (check_query, 'q="Service 12"', 1, {})
+    check_query('q="Service 12"', 1, {})
 
-    yield (check_query, 'q="Service -12"', 1, {})
-    yield (check_query, 'q=Service -12"', 119, {})
-    yield (check_query, 'q="Service -12', 119, {})
+    check_query('q="Service -12"', 1, {})
+    check_query('q=Service -12"', 119, {})
+    check_query('q="Service -12', 119, {})
 
-    yield (check_query, 'q="Service | -12"', 1, {})
-    yield (check_query, 'q="Service %26 12"', 1, {})
+    check_query('q="Service | -12"', 1, {})
+    check_query('q="Service %26 12"', 1, {})
 
 
 def test_negated_keyword_search():
-    yield (check_query,
-           'q=Service -12',
-           119, {})
+    check_query('q=Service -12', 119, {})
 
-    yield (check_query, 'q=12 -12', 0, {})
+    check_query('q=12 -12', 0, {})
 
 
 def test_or_keyword_search():
-    yield (check_query,
-           'q=Service || 12',
-           120, {})
+    check_query('q=Service || 12', 120, {})
 
-    yield (check_query, 'q=missing | 12', 1, {})
-    yield (check_query, 'q=missing || 12', 1, {})
+    check_query('q=missing | 12', 1, {})
+    check_query('q=missing || 12', 1, {})
 
 
 def test_escaped_characters():
-    yield (check_query, 'q=\\"Service | 12\\"', 120, {})
-    yield (check_query, 'q=\-12', 1, {})
-    yield (check_query, 'q=Service \|12', 1, {})
-    yield (check_query, 'q=Service \| 12', 0, {})
+    check_query('q=\\"Service | 12\\"', 120, {})
+    check_query('q=\-12', 1, {})
+    check_query('q=Service \|12', 1, {})
+    check_query('q=Service \| 12', 0, {})
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -254,7 +253,7 @@ def count_for_query(query, expected_count):
 
 
 def result_fields_check(query, check_fns):
-    services = query['services']
+    services = query['documents']
     for field in check_fns:
         ok_(all(check_fns[field](service[field]) for service in services),
             "Field '{}' check '{}' failed for search results:\n{}".format(


### PR DESCRIPTION
Part of this ticket: https://trello.com/c/KcqU7k20

### Add `filter_status` to briefs mapping
We want to be able to filter my status on the frontend, and so we need
this in the mapping.

### Return `documents` instead of `services`
When searching, the data that was being returned was behind a `services`
key. This updates to a more generic `documents`.