### PR TITLE
Update README so clear on which variable should be changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ has been generated (and has been deployed to the Search API server), this can be
 existing index endpoint:
 
 ```
-PUT /g-cloud-index HTTP/1.1
+PUT /<index_name> HTTP/1.1
 Authorization: Bearer myToken
 Content-Type: application/json
 


### PR DESCRIPTION
The PUT example used the URL which may seem to someone unfamiliar
with the repo to be a legitimate URL that should be used - however
it was only an example. Hopefully now it is clearer that the user
should create the URL themselves using a desired index name.