### PR TITLE
 Add `update_conditionally` transformation

### DIFF
--- a/app/main/services/process_request_json.py
+++ b/app/main/services/process_request_json.py
@@ -13,18 +13,7 @@ def _ensure_value_list(json_string_or_list):
         return [json_string_or_list]
 
 
-def _update_conditionally(arguments, document):
-    """
-    A transformation processor that updates field values in "target field" when
-    certain values are present in "field". The example use case is when
-    we are converting awarded, unsuccessful or cancelled brief status to closed.
-    :param arguments: dict -- the parameters to the processor as specified in configuration
-    :param document: dict -- the submitted document that we are transforming
-    """
-    _append_conditionally(arguments, document, update=True)
-
-
-def _append_conditionally(arguments, document, update=False):
+def _append_conditionally(arguments, document):
     """
     A transformation processor that generates new field values in "target field" when
     certain values are present in "field". The example use case is when
@@ -32,8 +21,20 @@ def _append_conditionally(arguments, document, update=False):
     is present.
     :param arguments: dict -- the parameters to the processor as specified in configuration
     :param document: dict -- the submitted document that we are transforming
-    :param update: bool -- if true, then the target field is updated instead of appended to. See the function above.
     """
+    _update_conditionally(arguments, document, append=True)
+
+
+def _update_conditionally(arguments, document, append=False):
+    """
+    A transformation processor that updates field values in "target field" when
+    certain values are present in "field". The example use case is when
+    we are converting awarded, unsuccessful or cancelled brief status to closed.
+    :param arguments: dict -- the parameters to the processor as specified in configuration
+    :param document: dict -- the submitted document that we are transforming
+    :param append: bool -- if true, then the target field is appended to instead updated. See the function above.
+    """
+
     source_field = arguments['field']
     target_field = arguments.get('target_field') or source_field
 
@@ -43,12 +44,12 @@ def _append_conditionally(arguments, document, update=False):
         target_values = _ensure_value_list(document.get(target_field, []))
 
         if any(value in source_values_set for value in arguments['any_of']):
-            if update:
-                document[target_field] = arguments['update_value']
-            else:
+            if append:
                 target_values.extend(arguments['append_value'])
                 # "append_value" key singular despite being a list, consistent with Elasticsearch practice
                 document[target_field] = target_values
+            else:
+                document[target_field] = arguments['update_value']
 
 
 def _hash_to(arguments, document):

--- a/app/main/services/process_request_json.py
+++ b/app/main/services/process_request_json.py
@@ -22,17 +22,17 @@ def _append_conditionally(arguments, document):
     :param arguments: dict -- the parameters to the processor as specified in configuration
     :param document: dict -- the submitted document that we are transforming
     """
-    _update_conditionally(arguments, document, append=True)
+    _set_conditionally(arguments, document, append=True)
 
 
-def _update_conditionally(arguments, document, append=False):
+def _set_conditionally(arguments, document, append=False):
     """
-    A transformation processor that updates field values in "target field" when
+    A transformation processor that sets field values in "target field" when
     certain values are present in "field". The example use case is when
     we are converting awarded, unsuccessful or cancelled brief status to closed.
     :param arguments: dict -- the parameters to the processor as specified in configuration
     :param document: dict -- the submitted document that we are transforming
-    :param append: bool -- if true, then the target field is appended to instead updated. See the function above.
+    :param append: bool -- if true, then the target field is appended to instead of set. See the function above.
     """
 
     source_field = arguments['field']
@@ -49,7 +49,7 @@ def _update_conditionally(arguments, document, append=False):
                 # "append_value" key singular despite being a list, consistent with Elasticsearch practice
                 document[target_field] = target_values
             else:
-                document[target_field] = arguments['update_value']
+                document[target_field] = arguments['set_value']
 
 
 def _hash_to(arguments, document):
@@ -69,7 +69,7 @@ def _hash_to(arguments, document):
 
 TRANSFORMATION_PROCESSORS = {
     'append_conditionally': _append_conditionally,
-    'update_conditionally': _update_conditionally,
+    'set_conditionally': _set_conditionally,
     'hash_to': _hash_to,
 }
 

--- a/app/main/services/process_request_json.py
+++ b/app/main/services/process_request_json.py
@@ -51,8 +51,28 @@ def _hash_to(arguments, document):
         document[target_field] = hashlib.sha256((six.text_type(document[source_field])).encode('utf-8')).hexdigest()
 
 
+def _update_conditionally(arguments, document):
+    """
+    A transformation processor that updates field values in "target field" when
+    certain values are present in "field". The example use case is when
+    we are converting awarded, unsuccessful or cancelled brief status to closed.
+    :param arguments: dict -- the parameters to the processor as specified in configuration
+    :param document: dict -- the submitted document that we are transforming
+    """
+    source_field = arguments['field']
+    target_field = arguments.get('target_field') or source_field
+
+    if source_field in document:
+        source_values = _ensure_value_list(document[source_field])
+        source_values_set = set(source_values)
+
+        if any(value in source_values_set for value in arguments['any_of']):
+            document[target_field] = arguments['update_value']
+
+
 TRANSFORMATION_PROCESSORS = {
     'append_conditionally': _append_conditionally,
+    'update_conditionally': _update_conditionally,
     'hash_to': _hash_to,
 }
 

--- a/mappings/briefs-digital-outcomes-and-specialists-2.json
+++ b/mappings/briefs-digital-outcomes-and-specialists-2.json
@@ -27,7 +27,7 @@
         "_": "DO NOT UPDATE BY HAND",
         "version": "10.0.0",
         "generated_from_framework": "digital-outcomes-and-specialists-2",
-        "generated_by": "/digitalmarketplace-frameworks/scripts/generate-search-config.py",
+        "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
         "generated_time": "2017-12-11T11:51:11.845511",
         "dm_sort_clause": [
           "sortonly_statusOrder",

--- a/mappings/briefs-digital-outcomes-and-specialists-2.json
+++ b/mappings/briefs-digital-outcomes-and-specialists-2.json
@@ -28,7 +28,7 @@
         "version": "10.1.0",
         "generated_from_framework": "digital-outcomes-and-specialists-2",
         "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2017-12-12T16:20:22.603265",
+        "generated_time": "2017-12-12T16:28:55.688469",
         "dm_sort_clause": [
           "sortonly_statusOrder",
           "sortonly_publishedAt",
@@ -151,6 +151,10 @@
         },
         "dmtext_status": {
           "type": "keyword"
+        },
+        "dmfilter_status": {
+          "type": "keyword",
+          "normalizer": "filter_normalizer"
         },
         "sortonly_statusOrder": {
           "type": "byte"

--- a/mappings/briefs-digital-outcomes-and-specialists-2.json
+++ b/mappings/briefs-digital-outcomes-and-specialists-2.json
@@ -25,10 +25,10 @@
     "briefs": {
       "_meta": {
         "_": "DO NOT UPDATE BY HAND",
-        "version": "10.0.0",
+        "version": "10.1.0",
         "generated_from_framework": "digital-outcomes-and-specialists-2",
         "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2017-12-11T11:51:11.845511",
+        "generated_time": "2017-12-12T16:20:22.603265",
         "dm_sort_clause": [
           "sortonly_statusOrder",
           "sortonly_publishedAt",
@@ -42,14 +42,14 @@
             }
           },
           {
-            "update_conditionally": {
+            "set_conditionally": {
               "field": "status",
               "any_of": [
                 "awarded",
                 "unsuccessful",
                 "cancelled"
               ],
-              "update_value": "closed"
+              "set_value": "closed"
             }
           },
           {

--- a/mappings/briefs-digital-outcomes-and-specialists-2.json
+++ b/mappings/briefs-digital-outcomes-and-specialists-2.json
@@ -27,8 +27,8 @@
         "_": "DO NOT UPDATE BY HAND",
         "version": "10.0.0",
         "generated_from_framework": "digital-outcomes-and-specialists-2",
-        "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2017-11-24T10:51:58.947073",
+        "generated_by": "/digitalmarketplace-frameworks/scripts/generate-search-config.py",
+        "generated_time": "2017-12-11T11:51:11.845511",
         "dm_sort_clause": [
           "sortonly_statusOrder",
           "sortonly_publishedAt",
@@ -39,6 +39,17 @@
             "hash_to": {
               "field": "id",
               "target_field": "idHash"
+            }
+          },
+          {
+            "update_conditionally": {
+              "field": "status",
+              "any_of": [
+                "awarded",
+                "unsuccessful",
+                "cancelled"
+              ],
+              "update_value": "closed"
             }
           },
           {

--- a/tests/app/services/test_process_request_json.py
+++ b/tests/app/services/test_process_request_json.py
@@ -158,12 +158,12 @@ def test_missing_field_in_transformation(services_mapping):
             }
         },
         {
-            "update_conditionally": {
+            "set_conditionally": {
                 "field": "supplierName",
                 "any_of": [
                     "foo",
                 ],
-                "update_value": [
+                "set_value": [
                     "bar"
                 ]
             }
@@ -209,18 +209,18 @@ def test_create_new_field_in_transformation(services_mapping):
     }
 
 
-class TestUpdateConditionally():
+class TestSetConditionally():
     def test_updates_source_field_when_no_target(self, services_mapping):
         services_mapping.transform_fields = [
             {
-                "update_conditionally": {
+                "set_conditionally": {
                     "field": "supplierName",
                     "any_of": [
                         "Red",
                         "Orange",
                         "Yellow"
                     ],
-                    "update_value": [
+                    "set_value": [
                         "Green"
                     ]
                 }
@@ -240,7 +240,7 @@ class TestUpdateConditionally():
     def test_updates_target_field(self, services_mapping):
         services_mapping.transform_fields = [
             {
-                "update_conditionally": {
+                "set_conditionally": {
                     "field": "supplierName",
                     "target_field": "serviceTypes",
                     "any_of": [
@@ -248,7 +248,7 @@ class TestUpdateConditionally():
                         "Indigo",
                         "Violet"
                     ],
-                    "update_value": [
+                    "set_value": [
                         "Pink"
                     ]
                 }
@@ -271,7 +271,7 @@ class TestUpdateConditionally():
     def test_creates_target_field_if_it_does_not_exist(self, services_mapping):
         services_mapping.transform_fields = [
             {
-                "update_conditionally": {
+                "set_conditionally": {
                     "field": "supplierName",
                     "target_field": "serviceTypes",
                     "any_of": [
@@ -279,7 +279,7 @@ class TestUpdateConditionally():
                         "Indigo",
                         "Violet"
                     ],
-                    "update_value": [
+                    "set_value": [
                         "Pink"
                     ]
                 }
@@ -301,14 +301,14 @@ class TestUpdateConditionally():
     def test_does_not_update_if_value_does_not_match(self, services_mapping):
         services_mapping.transform_fields = [
             {
-                "update_conditionally": {
+                "set_conditionally": {
                     "field": "supplierName",
                     "any_of": [
                         "Grey",
                         "Black",
                         "White"
                     ],
-                    "update_value": [
+                    "set_value": [
                         "Gold"
                     ]
                 }
@@ -328,14 +328,14 @@ class TestUpdateConditionally():
     def test_works_if_source_field_is_a_string(self, services_mapping):
         services_mapping.transform_fields = [
             {
-                "update_conditionally": {
+                "set_conditionally": {
                     "field": "supplierName",
                     "any_of": [
                         "Red",
                         "Orange",
                         "Yellow"
                     ],
-                    "update_value": "Green"
+                    "set_value": "Green"
                 }
             }
         ]


### PR DESCRIPTION
Part of this ticket: https://trello.com/c/KcqU7k20

A transformation to conditionally update the value of a field.

This is being created so that the value of the status field for a brief
being indexed can be changed from 'cancelled', 'withdrawn' or 'awarded' to
just 'closed'.

We will be rolling out the new statuses, but for now we just want to
maintain existing functionality.