### PR TITLE
Change from flake8-putty to per-file-ignores

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,7 +9,7 @@ exclude = venv*,__pycache__,node_modules,bower_components
 ignore = D203,W503
 max-complexity = 12
 max-line-length = 120
-putty-ignore =
-    **/__init__.py : +F401
-    app/main/__init__.py, app/status/__init__.py : +E402
-    app/main/__init__.py : +F403
+per-file-ignores =
+    **/__init__.py : F401
+    app/main/__init__.py : E402, F403
+    app/status/__init__.py : E402

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 coverage==3.7.1
-flake8==2.6.2
-flake8-putty==0.4.0
+flake8==3.5.0
+flake8-per-file-ignores==0.4.0
 mock==2.0.0
 nose==1.3.4  # nose.tools is still imported by tests
 pytest==3.1.3

--- a/scripts/index-g6-in-elasticsearch.py
+++ b/scripts/index-g6-in-elasticsearch.py
@@ -87,5 +87,6 @@ def main():
     else:
         print(__doc__)
 
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
Add flake8 per-file-ignores, in place of flake8-putty, so that we can support newer Python3 syntax like eg f-strings and type annotations.

Flake8 report:
```
/Users/samuelwilliams/git/digitalmarketplace-search-api/venv/bin/flake8 .
./scripts/index-g6-in-elasticsearch.py:90:1: E305 expected 2 blank lines after class or function definition, found 1
make: *** [test-flake8] Error 1
```