### PR TITLE
Sort briefs by publishedAt descending

### DIFF
--- a/mappings/briefs-digital-outcomes-and-specialists-2.json
+++ b/mappings/briefs-digital-outcomes-and-specialists-2.json
@@ -25,13 +25,15 @@
     "briefs": {
       "_meta": {
         "_": "DO NOT UPDATE BY HAND",
-        "version": "10.1.0",
+        "version": "10.1.1",
         "generated_from_framework": "digital-outcomes-and-specialists-2",
         "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2017-12-12T16:28:55.688469",
+        "generated_time": "2017-12-14T16:58:54.236771",
         "dm_sort_clause": [
           "sortonly_statusOrder",
-          "sortonly_publishedAt",
+          {
+            "sortonly_publishedAt": "desc"
+          },
           "sortonly_idHash"
         ],
         "transformations": [


### PR DESCRIPTION
Within a status, we want to sort briefs in descending chronological
order, so that new briefs appear higher up the list.

As the list of fields to sort by is passed directly to elasticsearch, we
can use elasticsearch syntax to change this ordering. This is what we've
done here.