### PR TITLE
Handle and log string status codes

### DIFF
--- a/app/main/services/response_formatters.py
+++ b/app/main/services/response_formatters.py
@@ -87,8 +87,8 @@ def api_response(data, status_code, key='message'):
     See http://elasticsearch-py.readthedocs.io/en/master/exceptions.html#elasticsearch.TransportError.status_code for
     an explaination of 'N/A' status code. elasticsearch-py client returns 'N/A' as status code if ES server cannot be
     reached, which is caught by `except TypeError` below.
-    It's possible that ElasticSearch can also return other unexpected non-integer status codes, which will also get
-    caught here, and returned as part of the JSON.
+    It's possible that the ElasticSearch library can also return other unexpected non-integer status codes, which will
+    also get caught here, logged, and returned as part of the JSON.
     """
     try:
         if status_code // 100 == 2:

--- a/app/main/services/response_formatters.py
+++ b/app/main/services/response_formatters.py
@@ -1,6 +1,6 @@
 import math
 
-from flask import jsonify
+from flask import current_app, jsonify
 
 
 def convert_es_status(index_name, status_response, info_response=None):
@@ -86,13 +86,14 @@ def api_response(data, status_code, key='message'):
 
     See http://elasticsearch-py.readthedocs.io/en/master/exceptions.html#elasticsearch.TransportError.status_code for
     an explaination of 'N/A' status code. elasticsearch-py client returns 'N/A' as status code if ES server cannot be
-    reached
+    reached, which is caught by `except TypeError` below.
+    It's possible that ElasticSearch can also return other unexpected non-integer status codes, which will also get
+    caught here, and returned as part of the JSON.
     """
     try:
         if status_code // 100 == 2:
             return jsonify({key: data}), status_code
-    except TypeError as e:
-        if status_code == 'N/A':
-            return jsonify(error=str(data)), 500
-        raise e
+    except TypeError:
+        current_app.logger.error(f'API response error: "{str(data)}" Unexpected status code: "{status_code}"')
+        return jsonify(error=str(data), unexpectedStatusCode=status_code), 500
     return jsonify(error=data), status_code

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,15 +29,10 @@ def services_mapping_definition():
         yield mock_definition_loader.return_value
 
 
-@pytest.fixture(scope="function", params=['service', 'document'])
-def default_service(request):
+@pytest.fixture(scope="function")
+def default_service():
     """
-    A fixture for a service such as might be indexed in the Search API. For now, parameterized so that we can test
-    both the old style where the structure had a top-level dictionary key hard-coded to 'service', and the new
-    style where we just look for a key 'document', which could be a DOS brief or a G-Cloud service or anything else.
+    A fixture for a service such as might be indexed in the Search API.
     :return: dict
     """
-    service = make_standard_service()
-    if request.param != 'document':
-        service = {request.param: service['document']}
-    return service
+    return make_standard_service()


### PR DESCRIPTION
In `api_response` we were catching `TypeErrors` when checking the status
code returned from elasticsearch. Elasticsearch has a weird thing where
it can return 'N/A' as the status code.

Previously we were checking if the status code was 'N/A' and handling it
if it was. If it wasn't we just reraised the TypeError.

This meant that we lost any info about the error returned by
Elasticsearch, and only got the stack trace leading to the TypeErrorin
the app.

We had a bunch of 500's caused by this, as Elasticsearch returned
something with a string as it's status code that wasn't 'N/A'. Due to
our lack of logging we don't know what it was.

This update will allow us to handle any string status codes, and log
them so we know what they are.