### PR TITLE
Dockerfile: bump base dependency to 2.1.1 to gain new nginx-nanosecond powers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:2.0.5
+FROM digitalmarketplace/base-api:2.1.1


### PR DESCRIPTION
see https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/690