### PR TITLE
services mapping: update, including max_result_window setting

### DIFF
--- a/mappings/briefs-digital-outcomes-and-specialists-2.json
+++ b/mappings/briefs-digital-outcomes-and-specialists-2.json
@@ -1,5 +1,8 @@
 {
   "settings": {
+    "index": {
+      "max_result_window": 10000
+    },
     "analysis": {
       "char_filter": {
         "nonalpha_removal": {
@@ -25,10 +28,10 @@
     "briefs": {
       "_meta": {
         "_": "DO NOT UPDATE BY HAND",
-        "version": "10.1.1",
+        "version": "10.2.1",
         "generated_from_framework": "digital-outcomes-and-specialists-2",
         "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2017-12-14T16:58:54.236771",
+        "generated_time": "2018-01-17T15:53:38.838590",
         "dm_sort_clause": [
           "sortonly_statusOrder",
           {

--- a/mappings/services.json
+++ b/mappings/services.json
@@ -1,5 +1,8 @@
 {
   "settings": {
+    "index": {
+      "max_result_window": 20000
+    },
     "analysis": {
       "analyzer": {
         "stemming_analyzer": {
@@ -45,17 +48,17 @@
   "mappings": {
     "services": {
       "_meta": {
+        "_": "DO NOT UPDATE BY HAND",
+        "version": "10.2.1",
+        "generated_from_framework": "g-cloud-9",
+        "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
+        "generated_time": "2018-01-17T15:53:05.466593",
         "dm_sort_clause": [
           "_score",
           {
             "sortonly_serviceIdHash": "desc"
           }
         ],
-        "_": "DO NOT UPDATE BY HAND",
-        "version": "9.3.0",
-        "generated_from_framework": "g-cloud-9",
-        "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2017-11-15T14:29:25.407239",
         "transformations": [
           {
             "hash_to": {

--- a/tests/fixtures/mappings/services.json
+++ b/tests/fixtures/mappings/services.json
@@ -1,5 +1,8 @@
 {
   "settings": {
+    "index": {
+      "max_result_window": 20000
+    },
     "analysis": {
       "char_filter": {
         "nonalpha_removal": {


### PR DESCRIPTION
Following on from https://github.com/alphagov/digitalmarketplace-frameworks/pull/492

Story https://trello.com/c/2wYwttWZ/171-500s-on-buyer-frontend-for-g-cloud-search-page-numbers-above-100

include similar change to test fixture mapping as better assurance that
this is consequence-free.