### PR TITLE
remove ability to update index mapping through attempting to "create" an existing index

### DIFF
--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -22,8 +22,6 @@ def create_index(index_name, mapping_name):
         es.indices.create(index=index_name, body=mapping_definition)
         return "acknowledged", 200
     except TransportError as e:
-        if 'index_already_exists_exception' in _get_an_error_message(e):
-            return put_index_mapping(index_name, mapping_definition)
         current_app.logger.warning(
             "Failed to create the index %s: %s",
             index, _get_an_error_message(e)
@@ -46,24 +44,6 @@ def create_alias(alias_name, target_index):
         return "acknowledged", 200
     except TransportError as e:
         return _get_an_error_message(e), e.status_code
-
-
-def put_index_mapping(index_name, definition):
-    for doc_type, mapping_for_type in definition["mappings"].items():
-        try:
-            es.indices.put_mapping(
-                index=index_name,
-                doc_type=doc_type,
-                body=mapping_for_type
-            )
-
-        except TransportError as e:
-            current_app.logger.error(
-                "Failed to update the index mapping for %s/%s: %s",
-                index, _get_an_error_message(e)
-            )
-            return _get_an_error_message(e), e.status_code
-    return "acknowledged", 200
 
 
 def delete_index(index_name):

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -49,7 +49,7 @@ class BaseApplicationTest(object):
     def do_not_provide_access_token(self):
         self.app.wsgi_app = self.app.wsgi_app.app
 
-    def create_index(self, index_name=None):
+    def create_index(self, index_name=None, expect_success=True):
         if index_name is None:
             index_name = self.default_index_name
 
@@ -57,7 +57,8 @@ class BaseApplicationTest(object):
             "type": "index",
             "mapping": self.default_mapping_name,
         }), content_type="application/json")
-        assert response.status_code in (200, 201)
+        if expect_success:
+            assert response.status_code in (200, 201)
         return response
 
     def teardown(self):

--- a/tests/app/views/test_admin.py
+++ b/tests/app/views/test_admin.py
@@ -1,4 +1,3 @@
-import mock
 import pytest
 from flask import json
 from nose.tools import assert_equal
@@ -104,22 +103,13 @@ class TestSearchIndexes(BaseApplicationTest):
         assert_equal(status['index-to-create']['aliases'], [])
         assert_equal(status['index-to-create-2']['aliases'], ['index-alias'])
 
-    def test_creating_existing_index_updates_mapping(self):
+    def test_creating_existing_index_fails(self):
         self.create_index()
 
-        with self.app.app_context():
-            with mock.patch(
-                'app.main.services.search_service.es.indices.put_mapping'
-            ) as es_mock:
-                response = self.create_index()
+        response = self.create_index(expect_success=False)
 
-        assert_response_status(response, 200)
-        assert_equal("acknowledged", get_json_from_response(response)["message"])
-        es_mock.assert_called_with(
-            index='index-to-create',
-            doc_type='services',
-            body=mock.ANY
-        )
+        assert_response_status(response, 400)
+        assert get_json_from_response(response)["error"].startswith("index_already_exists_exception:")
 
     def test_should_not_be_able_delete_index_twice(self):
         self.create_index()

--- a/tests/app/views/test_update.py
+++ b/tests/app/views/test_update.py
@@ -13,15 +13,10 @@ pytestmark = pytest.mark.usefixtures("services_mapping")
 
 
 class TestIndexingDocuments(BaseApplicationTestWithIndex):
-
     EXAMPLE_CONNECTION_ERROR = (
         '<urllib3.connection.HTTPConnection object at 0x107626588>: '
         'Failed to establish a new connection: [Errno 61] Connection refused'
     )
-
-    def setup(self):
-        super(TestIndexingDocuments, self).setup()
-        self.create_index()
 
     def test_should_index_a_document(self, default_service):
         service = default_service
@@ -135,8 +130,6 @@ class TestDeleteById(BaseApplicationTestWithIndex):
         assert_equal(data['error']['found'], False)
 
     def test_should_return_404_if_no_service(self):
-        self.create_index()
-
         response = self.client.delete(
             '/index-to-create/delete/100')
 


### PR DESCRIPTION
Trello https://trello.com/c/2wYwttWZ/171-500s-on-buyer-frontend-for-g-cloud-search-page-numbers-above-100

The existing implementation had the flaw that it failed to update the `settings` accompanying an updated mappings file. Fixing that proves to be quite tricky, mostly because ES will refuse to accept the attempted setting of "static" `settings` on a live index, even if they are unchanged from their previous values. This means we must determine which settings don't match those already on the index, as attempting to put any of them that are considered "static" would needlessly cause the update to fail. The difficulty in doing *that* comes from ES's habit of allowing deep-nested json object references `to.be.specified.like.this`, and in places allowing omission of levels of the nesting entirely. These things would all have to be normalized out and it seems like more code weight than it's worth, given that the feature still really doesn't buy us much - the few things that you're able to update on a live index generally require you to reindex anyway to gain the benefit from them.

TODO: update help & documentation of scripts/tools that mention this behaviour