### PR TITLE
Return 404s in (hopefully) all cases where a page beyond the available results is requested

### DIFF
--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -104,7 +104,9 @@ def status_for_all_indexes():
 
 
 def _page_404_response(requested_page):
-    return "Page {} does not exist for this search".format(requested_page), 404
+    return "{} does not exist for this search".format(
+        "This page" if requested_page is None else "Page {}".format(requested_page)
+    ), 404
 
 
 def core_search_and_aggregate(index_name, doc_type, query_args, search=False, aggregations=[]):
@@ -115,10 +117,11 @@ def core_search_and_aggregate(index_name, doc_type, query_args, search=False, ag
             page_size *= int(current_app.config['DM_ID_ONLY_SEARCH_PAGE_SIZE_MULTIPLIER'])
 
         es_search_kwargs = {'search_type': 'dfs_query_then_fetch'} if search else {}
+        constructed_query = construct_query(mapping, query_args, aggregations, page_size)
         res = es.search(
             index=index_name,
             doc_type=doc_type,
-            body=construct_query(mapping, query_args, aggregations, page_size),
+            body=constructed_query,
             **es_search_kwargs
         )
 
@@ -137,10 +140,17 @@ def core_search_and_aggregate(index_name, doc_type, query_args, search=False, ag
         }
 
         if aggregations:
-            response['aggregations'] = {}
             # Return aggregations in a slightly cleaner format.
-            for k, v in res.get('aggregations', {}).items():
-                response['aggregations'][k] = {d['key']: d['doc_count'] for d in v['buckets']}
+            response['aggregations'] = {
+                k: {d['key']: d['doc_count'] for d in v['buckets']}
+                for k, v in res.get('aggregations', {}).items()
+            }
+
+        # determine whether we're actually off the end of the results. ES handles this as a result-less-yet-happy
+        # response, but we probably want to turn it into a 404 not least so we can match our behaviour when fetching
+        # beyond the `max_result_window` below
+        if search and constructed_query.get("from") and not response["documents"]:
+            return _page_404_response(query_args.get("page", None))
 
         return response, 200
 
@@ -158,11 +168,9 @@ def core_search_and_aggregate(index_name, doc_type, query_args, search=False, ag
             except TransportError as e:
                 return _get_an_error_message(e), e.status_code
             else:
-                expected_page_count = (result_count // page_size) + (0 if result_count % page_size else 1)
-                requested_page = int(query_args.get("page", 1))
-                if expected_page_count < requested_page:
+                if result_count < constructed_query.get("from", 0):
                     # there genuinely aren't enough results for this number of pages, so this should be a 404
-                    return _page_404_response(requested_page)
+                    return _page_404_response(query_args.get("page", None))
                 # else fall through and allow this to 500 - we probably don't have max_result_window set high enough
                 # for the number of results it's possible to access using this index.
         return _get_an_error_message(e), e.status_code

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -94,17 +94,6 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
             assert_in("page=1", response_json['links']['prev'])
             assert_in("page=3", response_json['links']['next'])
 
-    def test_should_get_services_next_page_of_services(self):
-        with self.app.app_context():
-            self.app.config['DM_SEARCH_PAGE_SIZE'] = '5'
-            response = self.client.get(
-                '/index-to-create/services/search?q=serviceName')
-            assert_response_status(response, 200)
-            assert_equal(
-                get_json_from_response(response)["meta"]["total"], 10)
-            assert_equal(
-                len(get_json_from_response(response)["documents"]), 5)
-
     @pytest.mark.parametrize("page_size,page", (
         (5, 3,),
         (6, 3,),

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -116,6 +116,13 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
             assert_equal(
                 len(get_json_from_response(response)["documents"]), 0)
 
+    def test_should_get_404_on_massively_out_of_bounds_page(self):
+        with self.app.app_context():
+            self.app.config['DM_SEARCH_PAGE_SIZE'] = '50'
+            response = self.client.get(
+                '/index-to-create/services/search?q=serviceName&page=1000000')
+            assert_response_status(response, 404)
+
     def test_should_get_400_response__on_negative_page(self):
         with self.app.app_context():
             self.app.config['DM_SEARCH_PAGE_SIZE'] = '5'


### PR DESCRIPTION
Trello https://trello.com/c/kp4fXdEC/310-search-pages-still-500-instead-of-404ing

This introduces a few tricks to detect a couple of cases where we should be returning a 404:

* Firstly, catch situations where a 500 is returned because `max_result_window` is exceeded. in most cases these should be treated as a 404 but only after we've checked that we are actually requesting a page that wouldn't exist given the result count or whether we just haven't set the `max_result_window` high enough for this index. it does mean firing off another request just to be able to categorize the error, but that's probably worth it to be able to return something sane (and leave something less alarming in our logs).
* Additionally, return 404 in regular cases where a page is requested that is beyond the number of results, rather than the previous, ES-style behaviour of just returning a result-less-yet-happy response. This should allow us to at least match the previously mentioned behaviour when fetching a page beyond our `max_result_window`.