### PR TITLE
Use multiple ES host 'uris' field from PaaS config

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,7 +20,7 @@ def create_app(config_name):
 
     if application.config['VCAP_SERVICES']:
         cf_services = json.loads(application.config['VCAP_SERVICES'])
-        application.config['ELASTICSEARCH_HOST'] = cf_services['elasticsearch'][0]['credentials']['uri']
+        application.config['ELASTICSEARCH_HOST'] = cf_services['elasticsearch'][0]['credentials']['uris']
 
         with open(application.config['DM_ELASTICSEARCH_CERT_PATH'], 'wb') as es_certfile:
             es_certfile.write(base64.b64decode(cf_services['elasticsearch'][0]['credentials']['ca_certificate_base64']))


### PR DESCRIPTION
https://trello.com/c/fTjMGMix/185-paas-elasticsearch-vcapservices-changing

PaaS will shortly support multiple ES host URIs, for high availability (fingers crossed this has already happened, but it's being tested first before we switch to it).

This shouldn't require any changes to the Search API itself, just which key of the PaaS config we get the host URI(s) from. The Python elasticsearch client can happily cope with either a single host or a list of hosts.

For this PR I've put in a `try...except` to fall back to the old key, but this may be overkill. Thoughts welcome!