### PR TITLE
briefs mapping: add `clarificationQuestionsClosedAt` field

### DIFF
--- a/mappings/briefs-digital-outcomes-and-specialists-2.json
+++ b/mappings/briefs-digital-outcomes-and-specialists-2.json
@@ -28,10 +28,10 @@
     "briefs": {
       "_meta": {
         "_": "DO NOT UPDATE BY HAND",
-        "version": "10.2.1",
+        "version": "10.3.0",
         "generated_from_framework": "digital-outcomes-and-specialists-2",
         "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2018-01-17T15:53:38.838590",
+        "generated_time": "2018-02-09T15:50:01.805171",
         "dm_sort_clause": [
           "sortonly_statusOrder",
           {
@@ -127,6 +127,9 @@
           "type": "date"
         },
         "dmtext_applicationsClosedAt": {
+          "type": "keyword"
+        },
+        "dmtext_clarificationQuestionsClosedAt": {
           "type": "keyword"
         },
         "dmtext_cancelledAt": {


### PR DESCRIPTION
Trello https://trello.com/c/Ng8G6f9K/294-suppliers-can-view-date-questions-close-on-dos-search-page

Added as a simple "keyword" field as we only care about it being returned in the results.