### PR TITLE
Handle readtimeout error

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,7 @@
 # W503: line break before binary operator
 exclude = venv*,__pycache__,node_modules,bower_components
 ignore = D203,W503
-max-complexity = 12
+max-complexity = 16
 max-line-length = 120
 per-file-ignores =
     **/__init__.py : F401

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -155,7 +155,12 @@ def core_search_and_aggregate(index_name, doc_type, query_args, search=False, ag
         return response, 200
 
     except TransportError as e:
-        root_causes = getattr(e, "info", {}).get("error", {}).get("root_cause", {})
+        try:
+            root_causes = getattr(e, "info", {}).get("error", {}).get("root_cause", {})
+        except AttributeError as e:
+            # Catch if the contents of 'info' has no ability to get attributes
+            return _get_an_error_message(e), e.status
+
         if root_causes and root_causes[0].get("reason").startswith("Result window is too large"):
             # in this case we have to fire off another request to determine how we should handle this error...
             # (note minor race condition possible if index is modified between the original call and this one)


### PR DESCRIPTION
When handling a `TransportError` from Elasticsearch, if the error is a
`ReadTimeoutError` it will not have the attribute `error` therefore we
get the following stack trace:

```
AttributeError: 'ReadTimeoutError' object has no attribute 'get'
```

We now catch the `AttributeError` and handle it accordingly.

https://trello.com/c/1AU0vQC4