### PR TITLE
Update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:2.1.1
+FROM digitalmarketplace/base-api:3.1.1


### PR DESCRIPTION
Bump Dockerfile to api base 3.1.1 which pins versions of awscli/uwsgi/etc