### PR TITLE
briefs mapping: addition of text search

### DIFF
--- a/mappings/briefs-digital-outcomes-and-specialists-2.json
+++ b/mappings/briefs-digital-outcomes-and-specialists-2.json
@@ -4,6 +4,27 @@
       "max_result_window": 10000
     },
     "analysis": {
+      "analyzer": {
+        "stemming_analyzer": {
+          "tokenizer": "standard",
+          "filter": [
+            "standard",
+            "lowercase",
+            "possessive_english_stemmer",
+            "light_english_stemmer"
+          ]
+        }
+      },
+      "filter": {
+        "light_english_stemmer": {
+          "type": "stemmer",
+          "name": "light_english"
+        },
+        "possessive_english_stemmer": {
+          "type": "stemmer",
+          "name": "possessive_english"
+        }
+      },
       "char_filter": {
         "nonalpha_removal": {
           "type": "pattern_replace",
@@ -28,10 +49,10 @@
     "briefs": {
       "_meta": {
         "_": "DO NOT UPDATE BY HAND",
-        "version": "10.3.0",
+        "version": "10.5.0",
         "generated_from_framework": "digital-outcomes-and-specialists-2",
         "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2018-02-09T15:50:01.805171",
+        "generated_time": "2018-02-26T09:48:21.152711",
         "dm_sort_clause": [
           "sortonly_statusOrder",
           {
@@ -142,20 +163,32 @@
           "type": "keyword"
         },
         "dmtext_organisation": {
-          "type": "keyword"
+          "type": "text",
+          "analyzer": "stemming_analyzer"
         },
         "dmtext_title": {
-          "type": "keyword"
+          "type": "text",
+          "analyzer": "stemming_analyzer"
         },
         "dmtext_specialistRole": {
-          "type": "keyword"
+          "type": "text"
         },
         "dmfilter_specialistRole": {
           "type": "keyword",
           "normalizer": "filter_normalizer"
         },
         "dmtext_summary": {
-          "type": "keyword"
+          "term_vector": "with_positions_offsets",
+          "type": "text",
+          "analyzer": "stemming_analyzer"
+        },
+        "dmtext_essentialRequirements": {
+          "type": "text",
+          "analyzer": "stemming_analyzer"
+        },
+        "dmtext_niceToHaveRequirements": {
+          "type": "text",
+          "analyzer": "stemming_analyzer"
         },
         "dmtext_status": {
           "type": "keyword"
@@ -172,7 +205,7 @@
           "normalizer": "filter_normalizer"
         },
         "dmtext_location": {
-          "type": "keyword"
+          "type": "text"
         }
       }
     }


### PR DESCRIPTION
Corresponding to https://github.com/alphagov/digitalmarketplace-frameworks/pull/499 and https://trello.com/c/qdNbRJ4e/331-supplier-can-search-for-buyer-on-dos