### PR TITLE
request id handling: bump digitalmarketplace-utils dependency to 34.1.1

### DIFF
--- a/config.py
+++ b/config.py
@@ -24,8 +24,6 @@ class Config:
     DM_APP_NAME = 'search-api'
     DM_PLAIN_TEXT_LOGS = False
     DM_LOG_PATH = None
-    DM_REQUEST_ID_HEADER = 'DM-Request-ID'
-    DM_DOWNSTREAM_REQUEST_ID_HEADER = 'X-Amz-Cf-Id'
 
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -4,7 +4,7 @@
 Flask==0.10.1
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
 
 # Elasticsearch 5.0
 elasticsearch==5.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,48 +5,49 @@
 Flask==0.10.1
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@29.0.0#egg=digitalmarketplace-utils==29.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
 
 # Elasticsearch 5.0
 elasticsearch==5.4.0
 Flask-Elasticsearch==0.2.5
 
 ## The following requirements were added by pip freeze:
-asn1crypto==0.23.0
+asn1crypto==0.24.0
 boto3==1.4.4
 botocore==1.5.95
-certifi==2017.7.27.1
-cffi==1.11.2
+certifi==2018.1.18
+cffi==1.11.5
 chardet==3.0.4
 contextlib2==0.4.0
 cryptography==1.9
 docopt==0.4.0
 docutils==0.14
 Flask-FeatureFlags==0.6
+Flask-Login==0.4.1
 Flask-Script==2.0.5
 Flask-WTF==0.12
 future==0.16.0
 idna==2.6
 inflection==0.2.1
 itsdangerous==0.24
-Jinja2==2.9.6
+Jinja2==2.10
 jmespath==0.9.3
 mailchimp3==2.0.11
 mandrill==1.0.57
 MarkupSafe==1.0
 monotonic==0.3
 notifications-python-client==4.1.0
-odfpy==1.3.3
+odfpy==1.3.6
 pycparser==2.18
-PyJWT==1.5.3
+PyJWT==1.6.0
 python-dateutil==2.6.1
 pytz==2015.4
 PyYAML==3.11
 requests==2.18.4
-s3transfer==0.1.11
+s3transfer==0.1.13
 six==1.9.0
 unicodecsv==0.14.1
 urllib3==1.22
-Werkzeug==0.12.2
+Werkzeug==0.14.1
 workdays==1.4
 WTForms==2.1


### PR DESCRIPTION
...and re-freeze requirements.txt. This should bring in the new request id header handling.

https://trello.com/c/dlbLmRDB/343-make-use-of-zipkin-headers-in-preference-to-request-id-pt-1