### PR TITLE
Add field for filtering open and closed briefs

### DIFF
--- a/mappings/briefs-digital-outcomes-and-specialists-2.json
+++ b/mappings/briefs-digital-outcomes-and-specialists-2.json
@@ -49,10 +49,10 @@
     "briefs": {
       "_meta": {
         "_": "DO NOT UPDATE BY HAND",
-        "version": "10.5.0",
+        "version": "10.8.0",
         "generated_from_framework": "digital-outcomes-and-specialists-2",
-        "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2018-02-26T09:48:21.152711",
+        "generated_by": "/Users/brendanbutler/digitalmarketplace/digitalmarketplace-frameworks/scripts/generate-search-config.py",
+        "generated_time": "2018-03-12T17:29:23.097131",
         "dm_sort_clause": [
           "sortonly_statusOrder",
           {
@@ -65,6 +65,29 @@
             "hash_to": {
               "field": "id",
               "target_field": "idHash"
+            }
+          },
+          {
+            "set_conditionally": {
+              "field": "status",
+              "target_field": "statusOpenClosed",
+              "any_of": [
+                "live"
+              ],
+              "set_value": "open"
+            }
+          },
+          {
+            "set_conditionally": {
+              "field": "status",
+              "target_field": "statusOpenClosed",
+              "any_of": [
+                "awarded",
+                "cancelled",
+                "closed",
+                "unsuccessful"
+              ],
+              "set_value": "closed"
             }
           },
           {
@@ -194,6 +217,10 @@
           "type": "keyword"
         },
         "dmfilter_status": {
+          "type": "keyword",
+          "normalizer": "filter_normalizer"
+        },
+        "dmfilter_statusOpenClosed": {
           "type": "keyword",
           "normalizer": "filter_normalizer"
         },


### PR DESCRIPTION
We would like to show more detail about the status of an award in the search results for briefs. Currently the statuses are transformed in the search mapping to either 'open' or 'closed'.

We need to maintain the original status values for each brief in Elasticsearch whilst also retaining the current filtering ability.

This PR adds a brand new target field `statusOpenClosed` which will be used by the `buyer-frontend` to continue to filter on 'open' and 'closed' briefs. 

We are keeping the old transformations of the status field in place for the moment until the updates to the `buyer-frontend` have been made.

Corresponding PR:

- [x] https://github.com/alphagov/digitalmarketplace-frameworks/pull/506

https://trello.com/c/y59qiKOl/335-show-award-status-in-dos-search-results