### PR TITLE
Use centralised status method

### DIFF
--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,38 +1,24 @@
-from flask import jsonify, current_app, request
+from flask import request
 
 from . import status
 from ..main.services.search_service import status_for_all_indexes
-from dmutils.status import get_flags
+from dmutils.status import get_app_status, StatusError
+
+
+def get_es_status():
+    result, status_code = status_for_all_indexes()
+
+    if status_code != 200:
+        raise StatusError(f'Error connecting to elasticsearch (status_code: {status_code}, message: {result})')
+
+    return {
+        'es_status': result
+    }
 
 
 @status.route('/_status')
 def status():
-
-    if 'ignore-dependencies' in request.args:
-        return jsonify(
-            status="ok",
-        ), 200
-
-    result, status_code = status_for_all_indexes()
-    version = current_app.config['VERSION']
-
-    if status_code == 200:
-        return jsonify(
-            status="ok",
-            version=version,
-            es_status=result,
-            flags=get_flags(current_app)
-        )
-
-    current_app.logger.exception("Error connecting to elasticsearch")
-
-    return jsonify(
-        status="error",
-        version=version,
-        message="Error connecting to elasticsearch",
-        es_status={
-            'status_code': status_code,
-            'message': "{}".format(result),
-        },
-        flags=get_flags(current_app)
-    ), 500
+    return get_app_status(data_api_client=None,
+                          search_api_client=None,
+                          ignore_dependencies='ignore-dependencies' in request.args,
+                          additional_checks=[get_es_status])

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -4,7 +4,7 @@
 Flask==0.10.1
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
 
 # Elasticsearch 5.0
 elasticsearch==5.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 Flask==0.10.1
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@34.1.1#egg=digitalmarketplace-utils==34.1.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@35.2.0#egg=digitalmarketplace-utils==35.2.0
 
 # Elasticsearch 5.0
 elasticsearch==5.4.0
@@ -40,7 +40,7 @@ notifications-python-client==4.1.0
 odfpy==1.3.6
 pycparser==2.18
 PyJWT==1.6.0
-python-dateutil==2.6.1
+python-dateutil==2.7.0
 pytz==2015.4
 PyYAML==3.11
 requests==2.18.4

--- a/tests/app/views/test_status.py
+++ b/tests/app/views/test_status.py
@@ -27,4 +27,4 @@ class TestStatus(BaseApplicationTest):
             assert_equal(response.status_code, 500)
 
             data = json.loads(response.data.decode('utf-8'))
-            assert_equal(data['es_status']['message'], "FOO")
+            assert_equal(data['message'], ['Error connecting to elasticsearch (status_code: 500, message: FOO)'])


### PR DESCRIPTION
 ## Summary
The status endpoint for all of the apps is highly redundant across
repositories so I've moved it to dm-utils. We now only need to call this
method from the view stub in each app and pass in a couple of resources
(mainly the current_app and any api clients) to get a consistent status
JSON blob back.

 ## Ticket
https://trello.com/c/BBvu6eUk/383-ensure-healthcheck-endpoint-fails-if-low-disk-space