### PR TITLE
Avoid overwritting `e` attribute, this stores the error we care about

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,3 +13,4 @@ per-file-ignores =
     **/__init__.py : F401
     app/main/__init__.py : E402, F403
     app/status/__init__.py : E402
+    app/main/services/search_service.py : E731

--- a/app/main/services/response_formatters.py
+++ b/app/main/services/response_formatters.py
@@ -42,14 +42,15 @@ def _convert_es_result(mapping, es_result):
     }
 
 
-def convert_es_results(mapping, results, query_args, aggregations=False):
+def convert_es_results(mapping, results, query_args, aggregations=None, links=None):
     response = {
         "meta": {
             "query": query_args,
             "total": results["hits"]["total"],
             "took": results["took"],
         },
-        "documents": []
+        "documents": [],
+        "links": links
     }
 
     for document in results["hits"]["hits"]:
@@ -71,16 +72,15 @@ def convert_es_results(mapping, results, query_args, aggregations=False):
         }
     return response
 
-def generate_pagination_links(query_args, total, page_size, url_for_search):
-    page = int(query_args.get('page', 1))
-    max_page = int(math.ceil(float(total) / page_size))
-    args_no_page = {k: v for k, v in query_args.lists() if k != 'page'}
+
+def generate_pagination_links_for_url(url_method, current_page, page_size, total_results):
+    max_page = int(math.ceil(total_results / page_size))
 
     links = dict()
-    if page > 1:
-        links['prev'] = url_for_search(page=page - 1, **args_no_page)
-    if page < max_page:
-        links['next'] = url_for_search(page=page + 1, **args_no_page)
+    if current_page > 1:
+        links['prev'] = url_method(page=current_page - 1)
+    if current_page < max_page:
+        links['next'] = url_method(page=current_page + 1)
     return links
 
 

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -157,7 +157,7 @@ def core_search_and_aggregate(index_name, doc_type, query_args, search=False, ag
     except TransportError as e:
         try:
             root_causes = getattr(e, "info", {}).get("error", {}).get("root_cause", {})
-        except AttributeError as e:
+        except AttributeError:
             # Catch if the contents of 'info' has no ability to get attributes
             return _get_an_error_message(e), e.status
 

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -156,7 +156,7 @@ def core_search_and_aggregate(index_name, doc_type, query_args, search=False, ag
         return response, 200
 
     except TransportError as e:
-        error_message, status_code = _get_an_error_message(e), e.status
+        error_message, status_code = _get_an_error_message(e), e.status_code
         # Check if the error message matches 'not enough results exist for page number requested'
         pagination_error_re = '^.*?: (Result window is too large).*? \(.*?\)$'
         if re.match(pagination_error_re, error_message):


### PR DESCRIPTION
https://trello.com/c/5yZ9RfNk/512-low-test-coverage-on-coresearchandaggregate

https://trello.com/c/DiBqpPZW/344-search-api-500-30-06-18-am