### PR TITLE
Bugfix avoid resetting attribute e 2

### DIFF
--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -157,7 +157,7 @@ def core_search_and_aggregate(index_name, doc_type, query_args, search=False, ag
     except TransportError as e:
         try:
             root_causes = getattr(e, "info", {}).get("error", {}).get("root_cause", {})
-        except AttributeError as e:
+        except AttributeError:
             # Catch if the contents of 'info' has no ability to get attributes
             return _get_an_error_message(e), e.status
 

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -159,7 +159,7 @@ def core_search_and_aggregate(index_name, doc_type, query_args, search=False, ag
             root_causes = getattr(e, "info", {}).get("error", {}).get("root_cause", {})
         except AttributeError:
             # Catch if the contents of 'info' has no ability to get attributes
-            return _get_an_error_message(e), e.status
+            return _get_an_error_message(e), e.status_code
 
         if root_causes and root_causes[0].get("reason").startswith("Result window is too large"):
             # in this case we have to fire off another request to determine how we should handle this error...

--- a/tests/app/services/test_search_service.py
+++ b/tests/app/services/test_search_service.py
@@ -1,0 +1,29 @@
+import json
+import mock
+
+from elasticsearch import TransportError
+
+from ..helpers import BaseApplicationTestWithIndex
+
+
+class TestCoreSearchAndAggregate(BaseApplicationTestWithIndex):
+
+    @mock.patch('app.main.services.search_service.es')
+    def test_correct_exception_is_logged_with_info_attribute(self, es_mock):
+        es_mock.search.side_effect = TransportError(500, 'NewConnectionError', 'Temporary failure in name resolution')
+
+        response = self.client.get('/index-to-create/services/search')
+        data = json.loads(response.get_data())
+
+        assert response.status_code == 500
+        assert data['error'] == 'Temporary failure in name resolution'
+
+    @mock.patch('app.main.services.search_service.es')
+    def test_correct_exception_is_logged_without_info_attribute(self, es_mock):
+        es_mock.search.side_effect = TransportError(500, 'NewConnectionError', None)
+
+        response = self.client.get('/index-to-create/services/search')
+        data = json.loads(response.get_data())
+
+        assert response.status_code == 500
+        assert data['error'] is None


### PR DESCRIPTION
Search Kibana logs for requestId `88b88bbed572b0d7` will show an interesting error that wasn't handled properly by the search-api. This PR fixes the error handling to gracefully return and log the error.


https://trello.com/c/5yZ9RfNk/512-low-test-coverage-on-coresearchandaggregate

https://trello.com/c/DiBqpPZW/344-search-api-500-30-06-18-am