### PR TITLE
Change the VCAP_SERVICE key for elasticsearch

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,10 +20,13 @@ def create_app(config_name):
 
     if application.config['VCAP_SERVICES']:
         cf_services = json.loads(application.config['VCAP_SERVICES'])
-        application.config['ELASTICSEARCH_HOST'] = cf_services['elasticsearch'][0]['credentials']['uris']
+        application.config['ELASTICSEARCH_HOST'] = \
+            cf_services['elasticsearch-compose'][0]['credentials']['uris']
 
         with open(application.config['DM_ELASTICSEARCH_CERT_PATH'], 'wb') as es_certfile:
-            es_certfile.write(base64.b64decode(cf_services['elasticsearch'][0]['credentials']['ca_certificate_base64']))
+            es_certfile.write(
+                base64.b64decode(cf_services['elasticsearch-compose'][0]['credentials']['ca_certificate_base64'])
+            )
 
     elasticsearch_client.init_app(
         application,


### PR DESCRIPTION
GOV.UK PaaS have recently changed the name of their elasticsearch service in preparation for migration.

This quick fix will work until elasticsearch-compose is withdrawn; a future solution should use a more robust way of determining the elasticsearch URI.