### PR TITLE
Find elasticsearch URI in VCAP_SERVICES by tag

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,6 +9,16 @@ feature_flags = flask_featureflags.FeatureFlag()
 elasticsearch_client = FlaskElasticsearch()
 
 
+def get_service_by_tag_from_vcap_services(vcap_services, tag):
+    """Returns the first service from a VCAP_SERVICES json object that has tag"""
+    for services in vcap_services.values():
+        for service in services:
+            if tag in service['tags']:
+                return service
+
+    raise RuntimeError(f"Unable to find service with tag(s) {tag} in VCAP_SERVICES")
+
+
 def create_app(config_name):
     application = Flask(__name__)
 
@@ -20,12 +30,14 @@ def create_app(config_name):
 
     if application.config['VCAP_SERVICES']:
         cf_services = json.loads(application.config['VCAP_SERVICES'])
+        service = get_service_by_tag_from_vcap_services(cf_services, 'elasticsearch')
+
         application.config['ELASTICSEARCH_HOST'] = \
-            cf_services['elasticsearch-compose'][0]['credentials']['uris']
+            service['credentials']['uris']
 
         with open(application.config['DM_ELASTICSEARCH_CERT_PATH'], 'wb') as es_certfile:
             es_certfile.write(
-                base64.b64decode(cf_services['elasticsearch-compose'][0]['credentials']['ca_certificate_base64'])
+                base64.b64decode(service['credentials']['ca_certificate_base64'])
             )
 
     elasticsearch_client.init_app(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,53 @@
+
+from app import get_service_by_tag_from_vcap_services
+
+import pytest
+
+
+@pytest.fixture
+def elasticsearch_compose():
+    return {
+        "elasticsearch-compose": [{
+            "instance_name": "search_api_elasticsearch",
+            "label": "elasticsearch-compose",
+            "name": "search_api_elasticsearch",
+            "tags": [
+                "elasticsearch",
+                "compose",
+            ],
+        }]
+    }
+
+
+@pytest.fixture
+def elasticsearch():
+    return {
+        "elasticsearch": [{
+            "instance_name": "search_api_elasticsearch",
+            "label": "elasticsearch",
+            "name": "search_api_elasticsearch",
+            "tags": [
+                "elasticsearch",
+            ],
+        }]
+    }
+
+
+@pytest.fixture
+def multiple_services(elasticsearch, elasticsearch_compose):
+    return {**elasticsearch, **elasticsearch_compose}
+
+
+def test_get_service_by_tag_finds_elasticsearch_compose(elasticsearch_compose):
+    service = get_service_by_tag_from_vcap_services(elasticsearch_compose, 'elasticsearch')
+    assert service == elasticsearch_compose['elasticsearch-compose'][0]
+
+
+def test_get_service_by_tag_raises_runtime_error_if_it_cannot_find_the_service(elasticsearch_compose):
+    with pytest.raises(RuntimeError):
+        get_service_by_tag_from_vcap_services(elasticsearch_compose, 'garbage')
+
+
+def test_get_service_by_tag_finds_first_service_with_tag(multiple_services):
+    service = get_service_by_tag_from_vcap_services(multiple_services, 'elasticsearch')
+    assert service == multiple_services['elasticsearch'][0]


### PR DESCRIPTION
[Ticket](https://trello.com/c/C0FISeKl)

GOV.UK PaaS are planning to migrate from using Docker compose with elasticsearch. In preparation for this they changed the VCAP_SERVICE label from 'elasticsearch' to 'elasticsearch-compose' see (#153). In future, they will be changing the label back from 'elasticsearch-compose' to 'elasticsearch'.

This commit changes the way that we find the elasticsearch entry in VCAP_SERVICES to be robust to these changes; assuming that the service always contains the tag 'elasticsearch', `get_service_by_tag_from_vcap_services` should be able to find it.