### PR TITLE
Bump utils to 40.9.1

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -4,7 +4,7 @@
 Flask==0.10.1
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@40.9.0#egg=digitalmarketplace-utils==40.9.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@40.9.1#egg=digitalmarketplace-utils==40.9.1
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
 
 # Elasticsearch 5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 Flask==0.10.1
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@40.9.0#egg=digitalmarketplace-utils==40.9.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@40.9.1#egg=digitalmarketplace-utils==40.9.1
 git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
 
 # Elasticsearch 5.0


### PR DESCRIPTION
It pulls in a temporary (hopefully) fix to not configure the
urllib3.util.retry logger for the search api.

The Elasticsearch client causes it to generate a lot of unnecessary
logs. We're going to put a PR in upstream and see if we can get it fixed
there, but we'll go with this for now.