### PR TITLE
If `uris` is not in VCAP_SERVICES check `uri`

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -33,8 +33,13 @@ def create_app(config_name):
         service = get_service_by_name_from_vcap_services(
             cf_services, application.config['DM_ELASTICSEARCH_SERVICE_NAME'])
 
-        application.config['ELASTICSEARCH_HOST'] = \
-            service['credentials']['uris']
+        try:
+            application.config['ELASTICSEARCH_HOST'] = \
+                service['credentials']['uris']
+        except KeyError:
+            # uri is deprecated in favour of uris, but not all services respect this
+            application.config['ELASTICSEARCH_HOST'] = \
+                service['credentials']['uri']
 
         with open(application.config['DM_ELASTICSEARCH_CERT_PATH'], 'wb') as es_certfile:
             es_certfile.write(


### PR DESCRIPTION
This commit fixes a bug found during the procees of migrating PREVIEW to 
elasticsearch from Aiven (see https://trello.com/c/k6OgT7v4/)