### PR TITLE
Add a switch block to aid in migrating ElasticSearch provider

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -33,18 +33,28 @@ def create_app(config_name):
         service = get_service_by_name_from_vcap_services(
             cf_services, application.config['DM_ELASTICSEARCH_SERVICE_NAME'])
 
-        try:
-            application.config['ELASTICSEARCH_HOST'] = \
-                service['credentials']['uris']
-        except KeyError:
-            # uri is deprecated in favour of uris, but not all services respect this
+        service_provider = 'aiven'
+
+        if 'compose' in service['tags']:
+            service_provider = 'compose'
+
+        # remove switch block and DM_ELASTICSEARCH_CERT_PATH
+        # once ElasticSearch migration has been fully completed
+        if service_provider == 'aiven':
             application.config['ELASTICSEARCH_HOST'] = \
                 service['credentials']['uri']
 
-        with open(application.config['DM_ELASTICSEARCH_CERT_PATH'], 'wb') as es_certfile:
-            es_certfile.write(
-                base64.b64decode(service['credentials']['ca_certificate_base64'])
-            )
+            application.config['DM_ELASTICSEARCH_CERT_PATH'] = None
+
+        elif service_provider == 'compose':
+            application.config['ELASTICSEARCH_HOST'] = \
+                service['credentials']['uris']
+
+            # Compose PaaS service uses self-signed cert
+            with open(application.config['DM_ELASTICSEARCH_CERT_PATH'], 'wb') as es_certfile:
+                es_certfile.write(
+                    base64.b64decode(service['credentials']['ca_certificate_base64'])
+                )
 
     elasticsearch_client.init_app(
         application,


### PR DESCRIPTION
Change the application init so it takes different arguments from VCAP
services based on the service provider.

We detect the service provider based on the tags part of the service
object.

This code can be removed once migration is fully completed.

This is part of the [ElasticSearch migration ticket](https://trello.com/c/k6OgT7v4)