### PR TITLE
Update docker base image to v3.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:3.2.0
+FROM digitalmarketplace/base-api:3.3.0


### PR DESCRIPTION
Change the docker base tag to v3.3.0, which could in future be reseated to
newer images based on need for base image updates. This means the Docker image
can change without a commit being made to this repo.

This commit closes https://trello.com/c/8SHIo0gO