### PR TITLE
digitalmarketplace-utils dependency: bump to 43.0.0, remove featureflags references

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,9 +3,8 @@ import base64
 import json
 from config import config as configs
 from flask.ext.elasticsearch import FlaskElasticsearch
-from dmutils import init_app, flask_featureflags
+from dmutils import init_app
 
-feature_flags = flask_featureflags.FeatureFlag()
 elasticsearch_client = FlaskElasticsearch()
 
 
@@ -25,7 +24,6 @@ def create_app(config_name):
     init_app(
         application,
         configs[config_name],
-        feature_flags=feature_flags
     )
 
     if application.config['VCAP_SERVICES']:

--- a/config.py
+++ b/config.py
@@ -25,9 +25,6 @@ class Config:
     DM_PLAIN_TEXT_LOGS = False
     DM_LOG_PATH = None
 
-    # Feature Flags
-    RAISE_ERROR_ON_MISSING_FEATURES = True
-
     VCAP_SERVICES = None
     DM_ELASTICSEARCH_SERVICE_NAME = "search_api_elasticsearch"
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,11 +1,10 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==0.10.1
+Flask==0.12.4
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@41.2.1#egg=digitalmarketplace-utils==41.2.1
-git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0
 
 # Elasticsearch 5.0
 elasticsearch==5.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,10 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==0.10.1
+Flask==0.12.4
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@41.2.1#egg=digitalmarketplace-utils==41.2.1
-git+https://github.com/alphagov/Flask-FeatureFlags.git@1.0#egg=Flask-FeatureFlags==1.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0
 
 # Elasticsearch 5.0
 elasticsearch==5.4.0
@@ -16,9 +15,10 @@ Flask-Elasticsearch==0.2.5
 asn1crypto==0.24.0
 boto3==1.4.8
 botocore==1.8.50
-certifi==2018.4.16
+certifi==2018.8.13
 cffi==1.11.5
 chardet==3.0.4
+click==6.7
 contextlib2==0.4.0
 cryptography==2.3
 docopt==0.4.0


### PR DESCRIPTION
Trello https://trello.com/c/ZH9trgjH/419-snyk-alert-for-flask-010x-vulnerability

https://github.com/alphagov/digitalmarketplace-utils/pull/447

Nothing particularly exciting for this app.