### PR TITLE
18 flask 1x upgrade

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,8 +2,8 @@ from flask import Flask
 import base64
 import json
 from config import config as configs
-from flask.ext.elasticsearch import FlaskElasticsearch
-from dmutils import init_app
+from flask_elasticsearch import FlaskElasticsearch
+from dmutils import init_app, flask_featureflags
 
 elasticsearch_client = FlaskElasticsearch()
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,7 +3,7 @@ import base64
 import json
 from config import config as configs
 from flask_elasticsearch import FlaskElasticsearch
-from dmutils import init_app, flask_featureflags
+from dmutils import init_app
 
 elasticsearch_client = FlaskElasticsearch()
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,10 +1,10 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==0.12.4
+Flask==1.0.2
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.1#egg=digitalmarketplace-utils==44.0.1
 
 # Elasticsearch 5.0
 elasticsearch==5.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==0.12.4
+Flask==1.0.2
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
-git+https://github.com/alphagov/digitalmarketplace-utils.git@43.0.0#egg=digitalmarketplace-utils==43.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.1#egg=digitalmarketplace-utils==44.0.1
 
 # Elasticsearch 5.0
 elasticsearch==5.4.0
@@ -13,8 +13,8 @@ Flask-Elasticsearch==0.2.5
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
-boto3==1.4.8
-botocore==1.8.50
+boto3==1.7.83
+botocore==1.10.84
 certifi==2018.8.24
 cffi==1.11.5
 chardet==3.0.4
@@ -28,7 +28,6 @@ Flask-Script==2.0.6
 Flask-WTF==0.14.2
 future==0.16.0
 idna==2.7
-inflection==0.3.1
 itsdangerous==0.24
 Jinja2==2.10
 jmespath==0.9.3
@@ -42,7 +41,6 @@ pycparser==2.18
 PyJWT==1.6.4
 python-dateutil==2.7.3
 pytz==2015.4
-PyYAML==3.11
 requests==2.19.1
 s3transfer==0.1.13
 six==1.11.0


### PR DESCRIPTION
Upgrade to flask 1.0.2

* Update utils to 44.0.0
* Change imports from deprecated flask.ext to flask_  
> flask.ext - import extensions directly by their name instead of through the flask.ext namespace

http://flask.pocoo.org/docs/1.0/changelog/#version-1-0-2

https://trello.com/c/bBDir2Gp/18-flask-1x-upgrade