### PR TITLE
Add a test to indicate/ ensure that flask is performing retries 

### DIFF
--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -1,7 +1,11 @@
 """
 Tests for the application infrastructure
 """
+import mock
+import pytest
+
 from flask import json
+from elasticsearch.exceptions import ConnectionError
 from nose.tools import assert_equal
 
 from .helpers import BaseApplicationTest
@@ -33,3 +37,14 @@ class TestApplication(BaseApplicationTest):
     def test_ttl_is_not_set(self):
         response = self.client.get('/')
         assert_equal(None, response.cache_control.max_age)
+
+    @mock.patch('elasticsearch.transport.Urllib3HttpConnection.perform_request', side_effect=ConnectionError(500))
+    def test_elastic_search_client_performs_retries_on_connection_error(self, perform_request):
+        with pytest.raises(ConnectionError):
+            self.client.get('/')
+
+        # FlaskElasticsearch attaches the es client to the context in flask_elasticsearch.py
+        from flask import _app_ctx_stack
+
+        assert perform_request.call_count == 1 + _app_ctx_stack.top.elasticsearch.transport.max_retries
+        assert perform_request.call_count == 1 + 3


### PR DESCRIPTION
The retry functionality is buried in the elasticsearch.transport.Transport class and
can be effected by passing max_retries to the elasticsearch.client.ElasticSearch object
(https://github.com/elastic/elasticsearch-py/blob/master/elasticsearch/client/__init__.py#L184)
or the flask_elasticsearch.FlaskElasticsearch.init_app method. This test is an attempt
to surface this behaviour.