### PR TITLE
Add requires.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # digitalmarketplace-search-api
+
+[![Requirements Status](https://requires.io/github/alphagov/digitalmarketplace-search-api/requirements.svg?branch=master)](https://requires.io/github/alphagov/digitalmarketplace-search-api/requirements/?branch=master)
+
 API to handle interactions between the digitalmarketplace applications and search.
 
 - Python app, based on the [Flask framework](http://flask.pocoo.org/)


### PR DESCRIPTION
In readmes for other apps (see for instance https://github.com/alphagov/digitalmarketplace-api, https://github.com/alphagov/digitalmarketplace-user-frontend) we have a badge which gives a brief indication about the status of the requirements files; clicking the badge takes the user to a service, "requires.io", which gives more information.

Adding this badge to search-api makes it more consistent with the other apps.