### PR TITLE
Bump Docker base image to 4.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:4.0.0
+FROM digitalmarketplace/base-api:4.1.0


### PR DESCRIPTION
Bumps the Docker base image to 4.1.0:

- `metrics` nginx changes
