### PR TITLE
Unpin idna from requirements

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -3,7 +3,6 @@
 
 Flask==1.0.2
 itsdangerous==0.24
-idna==2.7
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
 git+https://github.com/alphagov/digitalmarketplace-utils.git@45.2.0#egg=digitalmarketplace-utils==45.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 
 Flask==1.0.2
 itsdangerous==0.24
-idna==2.7
 
 git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logger==v0.1.3
 git+https://github.com/alphagov/digitalmarketplace-utils.git@45.2.0#egg=digitalmarketplace-utils==45.2.0
@@ -31,21 +30,22 @@ Flask-Script==2.0.6
 Flask-WTF==0.14.2
 fleep==1.0.1
 future==0.17.1
+idna==2.8
 Jinja2==2.10
 jmespath==0.9.3
 mailchimp3==2.0.18
 mandrill==1.0.57
 MarkupSafe==1.1.0
 monotonic==1.5
-notifications-python-client==5.2.0
+notifications-python-client==5.3.0
 odfpy==1.4.0
 pycparser==2.19
 PyJWT==1.7.1
-python-dateutil==2.7.5
-pytz==2018.7
-requests==2.20.1
+python-dateutil==2.8.0
+pytz==2018.9
+requests==2.21.0
 s3transfer==0.1.13
-six==1.11.0
+six==1.12.0
 unicodecsv==0.14.1
 urllib3==1.24.1
 Werkzeug==0.14.1


### PR DESCRIPTION
Trello: https://trello.com/c/rT3obXh5/543-check-whether-idna-dependency-in-antivirus-api-requirements-apptxt-can-be-unpinned

We no longer need to pin `idna`; `requests 2.21.0` removes the requirement for idna to be < 2.8.

(See equivalent PR for the antivirus-api: https://github.com/alphagov/digitalmarketplace-antivirus-api/pull/33)