### PR TITLE
Update elasticsearch-py

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ API to handle interactions between the digitalmarketplace applications and searc
 
 ## Quickstart
 
-Install [elasticsearch](http://www.elasticsearch.org/). This must be in the 5.x series; ideally 5.4 which is what we run on live systems.
+Install [elasticsearch](http://www.elasticsearch.org/). This must be in the 5.x series; ideally 5.6 which is what we run on live systems.
 ```
 brew update
 brew cask install java
 cd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core
 git fetch --unshallow
-git checkout d8c57e111f1990c0a33b0d73af818eb8d442b33b Formula/elasticsearch.rb # (version: 5.4.2)
+git checkout 3f9a5fc50e42f6bdd17f955419c299653a0f65b9 Formula/elasticsearch.rb # (version: 5.6.4)
 HOMEBREW_NO_AUTO_UPDATE=1 brew install elasticsearch
 git reset --hard master
 ```

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,5 +8,5 @@ git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logg
 git+https://github.com/alphagov/digitalmarketplace-utils.git@45.2.0#egg=digitalmarketplace-utils==45.2.0
 
 # Elasticsearch 5.0
-elasticsearch==5.4.0 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
+elasticsearch==5.5.3 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
 Flask-Elasticsearch==0.2.5

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,5 +8,5 @@ git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logg
 git+https://github.com/alphagov/digitalmarketplace-utils.git@45.2.0#egg=digitalmarketplace-utils==45.2.0
 
 # Elasticsearch 5.0
-elasticsearch==5.4.0 # pyup: ignore
+elasticsearch==5.4.0 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
 Flask-Elasticsearch==0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ git+https://github.com/madzak/python-json-logger.git@v0.1.3#egg=python-json-logg
 git+https://github.com/alphagov/digitalmarketplace-utils.git@45.2.0#egg=digitalmarketplace-utils==45.2.0
 
 # Elasticsearch 5.0
-elasticsearch==5.4.0 # pyup: ignore
+elasticsearch==5.5.3 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
 Flask-Elasticsearch==0.2.5
 
 ## The following requirements were added by pip freeze:
@@ -17,7 +17,7 @@ asn1crypto==0.24.0
 boto3==1.7.83
 botocore==1.10.84
 certifi==2018.11.29
-cffi==1.12.1
+cffi==1.12.2
 chardet==3.0.4
 Click==7.0
 contextlib2==0.5.5


### PR DESCRIPTION
It turns out that we are now running Elasticsearch 5.6.13 in production, so I've updated the documentation to reflect this.

I also changed the requirements file so that we get the latest elasticsearch Python client; according to the client documentation any version in the 5.x series should be compatible with 5.x servers, so there's no reason not to upgrade. I added a PyUp filter to make sure we don't upgrade to 6.x until we're ready.