### PR TITLE
Update Elasticsearch version used by Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "3.6"
 env:
-  - ES_VERSION=5.4.2 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+  - ES_VERSION=5.6.13 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
 install:
   - wget ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz


### PR DESCRIPTION
I forgot to do this in #189.

The Travis tests should fail, due to the issue mentioned in #191. Once #191 is merged this can be safely merged.