### PR TITLE
Remove deprecated `include_in_all`

### DIFF
--- a/mappings/services-g-cloud-10.json
+++ b/mappings/services-g-cloud-10.json
@@ -49,10 +49,10 @@
     "services": {
       "_meta": {
         "_": "DO NOT UPDATE BY HAND",
-        "version": "12.2.0",
+        "version": "15.0.0",
         "generated_from_framework": "g-cloud-10",
         "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2018-06-27T16:13:14.577338",
+        "generated_time": "2019-03-06T09:18:21.596263",
         "dm_sort_clause": [
           "_score",
           {
@@ -694,8 +694,7 @@
           "type": "keyword"
         },
         "sortonly_serviceIdHash": {
-          "type": "keyword",
-          "include_in_all": false
+          "type": "keyword"
         },
         "dmagg_lot": {
           "type": "keyword"


### PR DESCRIPTION
Ticket: https://trello.com/c/uTA0PcGF

This commit updates the G-Cloud 10 service mapping using version 15.0.0 of the framework so that the deprecated Elasticsearch parameter `include_in_all` is removed (See alphagov/digitalmarketplace-frameworks#552 for more details).

This shouldn't actually make a difference to `search-api` as we never search using `_all`.

According to the readme, once this PR has been merged and released, the search-api still needs to be poked to tell it to change the Elasticsearch mapping; presumably this will also need a reindex.
