### PR TITLE
Use G-Cloud 10 services mapping in tests

### DIFF
--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import json
 

--- a/tests/app/helpers.py
+++ b/tests/app/helpers.py
@@ -8,7 +8,9 @@ from app import elasticsearch_client
 
 from ..conftest import (
     make_service,
+    services_mappings,
 )
+
 
 def build_query_params(keywords=None, page=None, filters=None):
     query_params = MultiDict()
@@ -44,7 +46,7 @@ class BaseApplicationTest(object):
         self.app = create_app('test')
         self.client = self.app.test_client()
         self.default_index_name = "test-index"
-        self.default_mapping_name = "services"
+        self.default_mapping_name = services_mappings[0]
 
         setup_authorization(self.app)
 

--- a/tests/app/services/test_process_request_json.py
+++ b/tests/app/services/test_process_request_json.py
@@ -1,10 +1,6 @@
-import pytest
 
 from app.main.services.process_request_json import \
     convert_request_json_into_index_json
-
-
-pytestmark = pytest.mark.usefixtures("services_mapping")
 
 
 def test_should_add_filter_fields_to_index_json(services_mapping):

--- a/tests/app/services/test_query_builder.py
+++ b/tests/app/services/test_query_builder.py
@@ -9,9 +9,6 @@ from werkzeug.datastructures import MultiDict
 from tests.app.helpers import build_query_params
 
 
-pytestmark = pytest.mark.usefixtures("services_mapping")
-
-
 def test_should_have_correct_root_element(services_mapping):
     assert "query" in construct_query(services_mapping, build_query_params())
 

--- a/tests/app/services/test_response_formatters.py
+++ b/tests/app/services/test_response_formatters.py
@@ -1,12 +1,7 @@
 from flask import json
 
-import pytest
-
 from app.main.services.response_formatters import \
     convert_es_status, convert_es_results
-
-
-pytestmark = pytest.mark.usefixtures("services_mapping")
 
 
 with open("example_es_responses/stats.json") as services:

--- a/tests/app/services/test_search_service.py
+++ b/tests/app/services/test_search_service.py
@@ -12,7 +12,7 @@ class TestCoreSearchAndAggregate(BaseApplicationTestWithIndex):
     def test_correct_exception_is_logged_with_info_attribute(self, es_mock):
         es_mock.search.side_effect = TransportError(500, 'NewConnectionError', 'Temporary failure in name resolution')
 
-        response = self.client.get('/index-to-create/services/search')
+        response = self.client.get('/test-index/services/search')
         data = json.loads(response.get_data())
 
         assert response.status_code == 500
@@ -22,7 +22,7 @@ class TestCoreSearchAndAggregate(BaseApplicationTestWithIndex):
     def test_correct_exception_is_logged_without_info_attribute(self, es_mock):
         es_mock.search.side_effect = TransportError(500, 'NewConnectionError', None)
 
-        response = self.client.get('/index-to-create/services/search')
+        response = self.client.get('/test-index/services/search')
         data = json.loads(response.get_data())
 
         assert response.status_code == 500

--- a/tests/app/views/test_admin.py
+++ b/tests/app/views/test_admin.py
@@ -1,107 +1,103 @@
-import pytest
 from flask import json
 
-from tests.app.helpers import BaseApplicationTest, assert_response_status, get_json_from_response
-
-
-pytestmark = pytest.mark.usefixtures("services_mapping")
+from tests.app.helpers import BaseApplicationTest, assert_response_status
 
 
 class TestSearchIndexes(BaseApplicationTest):
     def test_should_be_able_create_and_delete_index(self):
         response = self.create_index()
         assert_response_status(response, 200)
-        assert get_json_from_response(response)["message"] == "acknowledged"
+        assert response.json["message"] == "acknowledged"
 
-        response = self.client.get('/index-to-create')
+        response = self.client.get('/test-index')
         assert_response_status(response, 200)
 
-        response = self.client.delete('/index-to-create')
+        response = self.client.delete('/test-index')
         assert_response_status(response, 200)
-        assert get_json_from_response(response)["message"] == "acknowledged"
+        assert response.json["message"] == "acknowledged"
 
-        response = self.client.get('/index-to-create')
+        response = self.client.get('/test-index')
         assert_response_status(response, 404)
 
     def test_should_be_able_to_create_aliases(self):
         self.create_index()
         response = self.client.put('/index-alias', data=json.dumps({
             "type": "alias",
-            "target": "index-to-create"
+            "target": "test-index"
         }), content_type="application/json")
 
         assert_response_status(response, 200)
-        assert get_json_from_response(response)["message"] == "acknowledged"
+        assert response.json["message"] == "acknowledged"
 
     def test_should_not_be_able_to_delete_aliases(self):
         self.create_index()
         self.client.put('/index-alias', data=json.dumps({
             "type": "alias",
-            "target": "index-to-create"
+            "target": "test-index"
         }), content_type="application/json")
 
         response = self.client.delete('/index-alias')
 
         assert_response_status(response, 400)
-        assert get_json_from_response(response)["error"] == "Cannot delete alias 'index-alias'"
+        assert response.json["error"] == "Cannot delete alias 'index-alias'"
 
     def test_should_not_be_able_to_delete_index_with_alias(self):
         self.create_index()
         self.client.put('/index-alias', data=json.dumps({
             "type": "alias",
-            "target": "index-to-create"
+            "target": "test-index"
         }), content_type="application/json")
 
-        response = self.client.delete('/index-to-create')
+        response = self.client.delete('/test-index')
 
         assert_response_status(response, 400)
         assert (
-            get_json_from_response(response)["error"] ==
-            "Index 'index-to-create' is aliased as 'index-alias' and cannot be deleted"
+            response.json["error"] ==
+            "Index 'test-index' is aliased as 'index-alias' and cannot be deleted"
         )
 
     def test_cant_create_alias_for_missing_index(self):
         response = self.client.put('/index-alias', data=json.dumps({
             "type": "alias",
-            "target": "index-to-create"
+            "target": "test-index"
         }), content_type="application/json")
 
         assert_response_status(response, 404)
-        assert get_json_from_response(response)["error"].startswith(
+        assert response.json["error"].startswith(
             'index_not_found_exception: no such index')
 
     def test_cant_replace_index_with_alias(self):
         self.create_index()
-        response = self.client.put('/index-to-create', data=json.dumps({
+        response = self.client.put('/test-index', data=json.dumps({
             "type": "alias",
-            "target": "index-to-create"
+            "target": "test-index"
         }), content_type="application/json")
 
         assert_response_status(response, 400)
 
         expected_string = (
-            'invalid_alias_name_exception: Invalid alias name [index-to-create], an index exists with the same name '
-            'as the alias (index-to-create)'
+            'invalid_alias_name_exception: Invalid alias name [test-index], an index exists with the same name '
+            'as the alias (test-index)'
         )
-        assert get_json_from_response(response)["error"] == expected_string
+        assert response.json["error"] == expected_string
 
     def test_can_update_alias(self):
         self.create_index()
-        self.create_index('index-to-create-2')
+        self.create_index('test-index-2')
         self.client.put('/index-alias', data=json.dumps({
             "type": "alias",
-            "target": "index-to-create"
+            "target": "test-index"
         }), content_type="application/json")
 
         response = self.client.put('/index-alias', data=json.dumps({
             "type": "alias",
-            "target": "index-to-create-2"
+            "target": "test-index-2"
         }), content_type="application/json")
 
         assert_response_status(response, 200)
-        status = get_json_from_response(self.client.get('/_all'))["status"]
-        assert status['index-to-create']['aliases'] == []
-        assert status['index-to-create-2']['aliases'] == ['index-alias']
+        status = self.client.get('/_all').json["status"]
+        assert status['test-index']['aliases'] == []
+        assert status['test-index-2']['aliases'] == ['index-alias']
 
     def test_creating_existing_index_fails(self):
         self.create_index()
@@ -109,28 +105,28 @@ class TestSearchIndexes(BaseApplicationTest):
         response = self.create_index(expect_success=False)
 
         assert_response_status(response, 400)
-        assert get_json_from_response(response)["error"].startswith("index_already_exists_exception:")
+        assert response.json["error"].startswith("index_already_exists_exception:")
 
     def test_should_not_be_able_delete_index_twice(self):
         self.create_index()
-        self.client.delete('/index-to-create')
-        response = self.client.delete('/index-to-create')
+        self.client.delete('/test-index')
+        response = self.client.delete('/test-index')
         assert_response_status(response, 404)
-        assert get_json_from_response(response)["error"] == 'index_not_found_exception: no such index (index-to-create)'
+        assert response.json["error"] == 'index_not_found_exception: no such index (test-index)'
 
     def test_should_return_404_if_no_index(self):
         response = self.client.get('/index-does-not-exist')
         assert_response_status(response, 404)
         assert (
-            get_json_from_response(response)["error"] ==
+            response.json["error"] ==
             "index_not_found_exception: no such index (index-does-not-exist)"
         )
 
     def test_bad_mapping_name_gives_400(self):
-        response = self.client.put('/index-to-create', data=json.dumps({
+        response = self.client.put('/test-index', data=json.dumps({
             "type": "index",
             "mapping": "some-bad-mapping"
         }), content_type="application/json")
 
         assert_response_status(response, 400)
-        assert get_json_from_response(response)["error"] == "Mapping definition named 'some-bad-mapping' not found."
+        assert response.json["error"] == "Mapping definition named 'some-bad-mapping' not found."

--- a/tests/app/views/test_meta.py
+++ b/tests/app/views/test_meta.py
@@ -7,14 +7,14 @@ class TestMeta(BaseApplicationTestWithIndex):
         with self.app.app_context():
             self.client.put('/index-alias', data=json.dumps({
                 "type": "alias",
-                "target": "index-to-create",
+                "target": "test-index",
             }), content_type="application/json")
 
             response = self.client.get('/')
             response_data = json.loads(response.get_data())
 
             assert response.status_code == 200
-            assert {"href": "http://localhost/index-to-create/services/search",
+            assert {"href": "http://localhost/test-index/services/search",
                     "rel": "query.gdm.index",
                     } in response_data['links']
             assert {"href": "http://localhost/index-alias/services/search",

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -6,14 +6,15 @@ from werkzeug import MultiDict
 from app import elasticsearch_client as es
 from app.main.services import search_service
 from app.main.services.search_service import core_search_and_aggregate
-from tests.app.helpers import get_json_from_response
-from ..helpers import (BaseApplicationTestWithIndex, assert_response_status,
-                       make_search_api_url, make_standard_service)
+from ..helpers import (
+    BaseApplicationTestWithIndex,
+    assert_response_status,
+    create_services,
+    make_search_api_url,
+    make_service,
+)
 
-pytestmark = pytest.mark.usefixtures("services_mapping")
 
-
-@pytest.mark.usefixtures("services_mapping_definition")
 class TestSearchEndpoint(BaseApplicationTestWithIndex):
     def setup(self):
         super(TestSearchEndpoint, self).setup()
@@ -25,7 +26,7 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
                     data=json.dumps(service),
                     content_type='application/json')
                 assert response.status_code == 200
-            search_service.refresh('index-to-create')
+            search_service.refresh('test-index')
 
     def _put_into_and_get_back_from_elasticsearch(self, service, query_string):
 
@@ -34,14 +35,13 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
             data=json.dumps(service), content_type='application/json')
 
         with self.app.app_context():
-            search_service.refresh('index-to-create')
+            search_service.refresh('test-index')
 
         return self.client.get(
-            '/index-to-create/services/search?{}'.format(query_string)
+            '/test-index/services/search?{}'.format(query_string)
         )
 
-    def test_should_return_service_on_id(self, default_service):
-        service = default_service
+    def test_should_return_service_on_id(self, service):
         response = self.client.put(
             make_search_api_url(service),
             data=json.dumps(service),
@@ -51,40 +51,40 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
     def test_should_return_service_on_keyword_search(self):
         with self.app.app_context():
             response = self.client.get(
-                '/index-to-create/services/search?q=serviceName')
+                '/test-index/services/search?q=serviceName')
             assert_response_status(response, 200)
-            assert get_json_from_response(response)["meta"]["total"] == 10
+            assert response.json["meta"]["total"] == 10
 
     def test_keyword_search_via_alias(self):
         with self.app.app_context():
             self.client.put('/{}'.format('index-alias'), data=json.dumps({
                 "type": "alias",
-                "target": "index-to-create",
+                "target": "test-index",
             }), content_type="application/json")
             response = self.client.get(
                 '/index-alias/services/search?q=serviceName')
             assert_response_status(response, 200)
-            assert get_json_from_response(response)["meta"]["total"] == 10
+            assert response.json["meta"]["total"] == 10
 
     def test_should_get_services_up_to_page_size(self):
         with self.app.app_context():
             self.app.config['DM_SEARCH_PAGE_SIZE'] = '5'
 
             response = self.client.get(
-                '/index-to-create/services/search?q=serviceName'
+                '/test-index/services/search?q=serviceName'
             )
             assert_response_status(response, 200)
 
-            assert get_json_from_response(response)["meta"]["total"] == 10
-            assert len(get_json_from_response(response)["documents"]) == 5
+            assert response.json["meta"]["total"] == 10
+            assert len(response.json["documents"]) == 5
 
     def test_should_get_pagination_links(self):
         with self.app.app_context():
             self.app.config['DM_SEARCH_PAGE_SIZE'] = '3'
 
             response = self.client.get(
-                '/index-to-create/services/search?q=serviceName&page=2')
-            response_json = get_json_from_response(response)
+                '/test-index/services/search?q=serviceName&page=2')
+            response_json = response.json
 
             assert_response_status(response, 200)
             assert "page=1" in response_json['links']['prev']
@@ -106,7 +106,7 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
         with self.app.app_context():
             self.app.config['DM_SEARCH_PAGE_SIZE'] = str(page_size)
             response = self.client.get(
-                '/index-to-create/services/search?q=serviceName&page={}'.format(page)
+                '/test-index/services/search?q=serviceName&page={}'.format(page)
             )
             assert_response_status(response, 404)
 
@@ -114,18 +114,18 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
         with self.app.app_context():
             self.app.config['DM_SEARCH_PAGE_SIZE'] = '5'
             response = self.client.get(
-                '/index-to-create/services/search?q=serviceName&page=-1')
+                '/test-index/services/search?q=serviceName&page=-1')
             assert_response_status(response, 400)
 
     def test_should_get_400_response__on_non_numeric_page(self):
         with self.app.app_context():
             self.app.config['DM_SEARCH_PAGE_SIZE'] = '5'
             response = self.client.get(
-                '/index-to-create/services/search?q=serviceName&page=foo')
+                '/test-index/services/search?q=serviceName&page=foo')
             assert_response_status(response, 400)
 
     def test_highlighting_should_use_defined_html_tags(self):
-        service = make_standard_service(
+        service = make_service(
             serviceDescription="Accessing, storing and retaining email"
         )
         highlighted_summary = \
@@ -136,13 +136,11 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
             query_string='q=storing'
         )
         assert_response_status(response, 200)
-        search_results = get_json_from_response(
-            response
-        )["documents"]
+        search_results = response.json["documents"]
         assert search_results[0]["highlight"]["serviceDescription"][0] == highlighted_summary
 
     def test_highlighting_should_escape_html(self):
-        service = make_standard_service(
+        service = make_service(
             serviceDescription="accessing, storing <h1>and retaining</h1> email"
         )
 
@@ -151,7 +149,7 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
             query_string='q=storing'
         )
         assert_response_status(response, 200)
-        search_results = get_json_from_response(response)["documents"]
+        search_results = response.json["documents"]
         expected_string = (
             "accessing, <mark class='search-result-highlighted-text'>storing</mark> &lt;h1&gt;and retaining"
             "&lt;&#x2F;h1&gt; email"
@@ -159,7 +157,7 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
         assert search_results[0]["highlight"]["serviceDescription"][0] == expected_string
 
     def test_unhighlighted_result_should_escape_html(self):
-        service = make_standard_service(
+        service = make_service(
             serviceDescription='Oh <script>alert("Yo");</script>',
             lot='oY'
         )
@@ -169,7 +167,7 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
             query_string='q=oY'
         )
         assert_response_status(response, 200)
-        search_results = get_json_from_response(response)["documents"]
+        search_results = response.json["documents"]
         expected_string = "Oh &lt;script&gt;alert(&quot;Yo&quot;);&lt;&#x2F;script&gt;"
         assert search_results[0]["highlight"]["serviceDescription"][0] == expected_string
 
@@ -178,7 +176,7 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
         # 120 words, 600 characters
         really_long_service_summary = "This line has a total of 10 words, 50 characters. " * 12
 
-        service = make_standard_service(
+        service = make_service(
             serviceDescription=really_long_service_summary,
             lot='TaaS'
         )
@@ -189,7 +187,7 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
         )
         assert_response_status(response, 200)
 
-        search_results = get_json_from_response(response)["documents"]
+        search_results = response.json["documents"]
         # Get the first with a matching value from a list
         search_result = next((s for s in search_results if s['lot'] == 'TaaS'), None)
         assert 490 < len(search_result["highlight"]["serviceDescription"][0]) < 510
@@ -206,8 +204,8 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
             self.app.config['DM_ID_ONLY_SEARCH_PAGE_SIZE_MULTIPLIER'] = multiplier
 
             response = self.client.get(
-                '/index-to-create/services/search?q=serviceName&idOnly=True')
-            response_json = get_json_from_response(response)
+                '/test-index/services/search?q=serviceName&idOnly=True')
+            response_json = response.json
 
             assert_response_status(response, 200)
             assert len(response_json['documents']) == expected_count
@@ -215,8 +213,8 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
     def test_only_ids_returned_for_id_only_request(self):
         with self.app.app_context():
             response = self.client.get(
-                '/index-to-create/services/search?q=serviceName&idOnly=True')
-            response_json = get_json_from_response(response)
+                '/test-index/services/search?q=serviceName&idOnly=True')
+            response_json = response.json
 
             assert_response_status(response, 200)
             assert set(response_json['documents'][0].keys()) == {'id'}
@@ -225,12 +223,11 @@ class TestSearchEndpoint(BaseApplicationTestWithIndex):
 class TestFetchById(BaseApplicationTestWithIndex):
     def test_should_return_404_if_no_service(self):
         response = self.client.get(
-            '/index-to-create/services/100')
+            '/test-index/services/100')
 
         assert_response_status(response, 404)
 
-    def test_should_return_service_by_id(self, default_service):
-        service = default_service
+    def test_should_return_service_by_id(self, service):
         self.client.put(
             make_search_api_url(service),
             data=json.dumps(service),
@@ -238,11 +235,11 @@ class TestFetchById(BaseApplicationTestWithIndex):
         )
 
         with self.app.app_context():
-            search_service.refresh('index-to-create')
+            search_service.refresh('test-index')
 
         response = self.client.get(make_search_api_url(service))
 
-        data = get_json_from_response(response)
+        data = response.json
         assert_response_status(response, 200)
 
         original_service_id = service.get('document', service.get('service'))['id']  # TODO remove compat shim
@@ -266,8 +263,7 @@ class TestFetchById(BaseApplicationTestWithIndex):
             indexed = data['services']["_source"]["dmtext_" + key]
             assert original == indexed
 
-    def test_service_should_have_all_exact_match_fields(self, default_service):
-        service = default_service
+    def test_service_should_have_all_exact_match_fields(self, service):
         self.client.put(
             make_search_api_url(service),
             data=json.dumps(service),
@@ -275,10 +271,10 @@ class TestFetchById(BaseApplicationTestWithIndex):
         )
 
         with self.app.app_context():
-            search_service.refresh('index-to-create')
+            search_service.refresh('test-index')
         response = self.client.get(make_search_api_url(service))
 
-        data = get_json_from_response(response)
+        data = response.json
         assert_response_status(response, 200)
 
         cases = [
@@ -297,13 +293,13 @@ class TestFetchById(BaseApplicationTestWithIndex):
 class TestSearchType(BaseApplicationTestWithIndex):
     def test_core_search_and_aggregate_does_dfs_query_for_searches(self):
         with self.app.app_context(), mock.patch.object(es, 'search') as es_search_mock:
-            core_search_and_aggregate('index-to-create', 'services', MultiDict(), search=True)
+            core_search_and_aggregate('test-index', 'services', MultiDict(), search=True)
 
         assert es_search_mock.call_args[1]['search_type'] == 'dfs_query_then_fetch'
 
     def test_core_search_and_aggregate_does_size_0_query_for_aggregations(self):
         with self.app.app_context(), mock.patch.object(es, 'search') as es_search_mock:
-            core_search_and_aggregate('index-to-create', 'services', MultiDict(), aggregations=['serviceCategories'])
+            core_search_and_aggregate('test-index', 'services', MultiDict(), aggregations=['serviceCategories'])
 
         assert es_search_mock.call_args[1]['body']['size'] == 0
 
@@ -318,22 +314,13 @@ class TestSearchResultsOrdering(BaseApplicationTestWithIndex):
                     make_search_api_url(service),
                     data=json.dumps(service),
                     content_type='application/json')
-            search_service.refresh('index-to-create')
+            search_service.refresh('test-index')
 
     def test_should_order_services_by_service_id_sha256(self):
         with self.app.app_context():
-            response = self.client.get('/index-to-create/services/search')
+            response = self.client.get('/test-index/services/search')
             assert_response_status(response, 200)
-            assert get_json_from_response(response)["meta"]["total"] == 10
+            assert response.json["meta"]["total"] == 10
 
         ordered_service_ids = [service['id'] for service in json.loads(response.get_data(as_text=True))['documents']]
         assert ordered_service_ids == ['5', '6', '2', '7', '1', '0', '3', '4', '8', '9']  # fixture for sha256 ordering
-
-
-def create_services(number_of_services):
-    services = []
-    for i in range(number_of_services):
-        service = make_standard_service(id=str(i))
-        services.append(service)
-
-    return services

--- a/tests/app/views/test_search_queries.py
+++ b/tests/app/views/test_search_queries.py
@@ -7,7 +7,7 @@ from ..helpers import setup_authorization, make_service
 
 
 @pytest.fixture(scope='module', autouse=True)
-def dummy_services():
+def dummy_services(services_mapping_file_name_and_path):
     """Fixture that indexes a bunch of fake G-Cloud services so that searching can be tested."""
 
     app = create_app('test')
@@ -17,7 +17,7 @@ def dummy_services():
     with app.app_context():
         response = test_client.put(
             '/test-index',
-            data=json.dumps({"type": "index", "mapping": "services", }),
+            data=json.dumps({"type": "index", "mapping": services_mapping_file_name_and_path[0]}),
             content_type="application/json",
         )
         assert response.status_code in (200, 201)

--- a/tests/app/views/test_search_queries.py
+++ b/tests/app/views/test_search_queries.py
@@ -3,7 +3,33 @@ from flask import json
 import pytest
 
 from app import create_app
-from ..helpers import setup_authorization, make_standard_service
+from ..helpers import setup_authorization, make_service
+
+
+@pytest.fixture(scope='module', autouse=True)
+def dummy_services():
+    """Fixture that indexes a bunch of fake G-Cloud services so that searching can be tested."""
+
+    app = create_app('test')
+    test_client = app.test_client()
+
+    setup_authorization(app)
+    with app.app_context():
+        response = test_client.put(
+            '/test-index',
+            data=json.dumps({"type": "index", "mapping": "services", }),
+            content_type="application/json",
+        )
+        assert response.status_code in (200, 201)
+        services = list(create_services(120))
+        for service in services:
+            test_client.put(
+                '/test-index/services/%s' % service["document"]["id"],
+                data=json.dumps(service), content_type='application/json'
+            )
+            search_service.refresh('test-index')
+    yield
+    test_client.delete('/test-index')
 
 
 # Helpers for 'result_fields_check'
@@ -180,37 +206,11 @@ def test_escaped_characters():
     check_query(r'q=Service \| 12', 0, {})
 
 
-@pytest.fixture(scope='module', autouse=True)
-def dummy_services(services_mapping_definition):
-    """Fixture that indexes a bunch of fake G-Cloud services so that searching can be tested."""
-
-    app = create_app('test')
-    test_client = app.test_client()
-
-    setup_authorization(app)
-    with app.app_context():
-        response = test_client.put(
-            '/index-to-create',
-            data=json.dumps({"type": "index", "mapping": "services", }),
-            content_type="application/json",
-        )
-        assert response.status_code in (200, 201)
-        services = list(create_services(120))
-        for service in services:
-            test_client.put(
-                '/index-to-create/services/%s' % service["document"]["id"],
-                data=json.dumps(service), content_type='application/json'
-            )
-            search_service.refresh('index-to-create')
-    yield
-    test_client.delete('/index-to-create')
-
-
 # '/search' request helpers
 
 def create_services(number_of_services):
     for i in range(number_of_services):
-        yield make_standard_service(
+        yield make_service(
             id=str(i),
             serviceName="Service {}".format(i),
             phoneSupport=bool(i % 2),
@@ -233,7 +233,7 @@ def search_results(query):
     test_client = app.test_client()
     setup_authorization(app)
 
-    response = test_client.get('/index-to-create/services/search?%s' % query)
+    response = test_client.get('/test-index/services/search?%s' % query)
     return json.loads(response.get_data())
 
 
@@ -242,7 +242,7 @@ def aggregations_results(query):
     test_client = app.test_client()
     setup_authorization(app)
 
-    response = test_client.get('/index-to-create/services/aggregations?{}&aggregations=lot'.format(query))
+    response = test_client.get('/test-index/services/aggregations?{}&aggregations=lot'.format(query))
     return json.loads(response.get_data())
 
 

--- a/tests/app/views/test_update.py
+++ b/tests/app/views/test_update.py
@@ -4,11 +4,7 @@ from flask import json
 from urllib3.exceptions import NewConnectionError
 
 from app.main.services import search_service
-from tests.app.helpers import BaseApplicationTestWithIndex, make_search_api_url, assert_response_status, \
-    get_json_from_response
-
-
-pytestmark = pytest.mark.usefixtures("services_mapping")
+from tests.app.helpers import BaseApplicationTestWithIndex, make_search_api_url, assert_response_status
 
 
 class TestIndexingDocuments(BaseApplicationTestWithIndex):
@@ -17,9 +13,7 @@ class TestIndexingDocuments(BaseApplicationTestWithIndex):
         'Failed to establish a new connection: [Errno 61] Connection refused'
     )
 
-    def test_should_index_a_document(self, default_service):
-        service = default_service
-
+    def test_should_index_a_document(self, service):
         response = self.client.put(
             make_search_api_url(service),
             data=json.dumps(service),
@@ -28,17 +22,16 @@ class TestIndexingDocuments(BaseApplicationTestWithIndex):
         assert_response_status(response, 200)
 
         with self.app.app_context():
-            search_service.refresh('index-to-create')
-        response = self.client.get('/index-to-create')
+            search_service.refresh('test-index')
+        response = self.client.get('/test-index')
         assert_response_status(response, 200)
-        assert get_json_from_response(response)["status"]["num_docs"] == 1
+        assert response.json["status"]["num_docs"] == 1
 
     @mock.patch('app.main.views.update.index')
     @mock.patch('app.main.services.response_formatters.current_app')
     @pytest.mark.parametrize('error_status_code', ['N/A', 'something_other_than_N/A'])
-    def test_index_document_handles_connection_error(self, current_app, index, error_status_code, default_service):
+    def test_index_document_handles_connection_error(self, current_app, index, error_status_code, service):
         index.return_value = (NewConnectionError('', self.EXAMPLE_CONNECTION_ERROR), error_status_code)
-        service = default_service
 
         response = self.client.put(
             make_search_api_url(service),
@@ -50,8 +43,7 @@ class TestIndexingDocuments(BaseApplicationTestWithIndex):
             f'API response error: ": {self.EXAMPLE_CONNECTION_ERROR}" Unexpected status code: "{error_status_code}"'
         )
 
-    def test_should_index_a_document_with_missing_fields(self, default_service):
-        service = default_service
+    def test_should_index_a_document_with_missing_fields(self, service):
         del service.get('document', service.get('service'))["serviceName"]
 
         response = self.client.put(
@@ -61,8 +53,7 @@ class TestIndexingDocuments(BaseApplicationTestWithIndex):
 
         assert_response_status(response, 200)
 
-    def test_should_index_a_document_with_extra_fields(self, default_service):
-        service = default_service
+    def test_should_index_a_document_with_extra_fields(self, service):
         service.get('document', service.get('service'))["randomField"] = "some random"
 
         response = self.client.put(
@@ -72,8 +63,7 @@ class TestIndexingDocuments(BaseApplicationTestWithIndex):
 
         assert_response_status(response, 200)
 
-    def test_should_index_a_document_with_incorrect_types(self, default_service):
-        service = default_service
+    def test_should_index_a_document_with_incorrect_types(self, service):
         service.get('document', service.get('service'))["serviceName"] = 123
 
         response = self.client.put(
@@ -83,8 +73,7 @@ class TestIndexingDocuments(BaseApplicationTestWithIndex):
 
         assert_response_status(response, 200)
 
-    def test_should_index_a_document_with_no_service_types(self, default_service):
-        service = default_service
+    def test_should_index_a_document_with_no_service_types(self, service):
         service.get('document', service.get('service'))["serviceName"] = 123
         del service.get('document', service.get('service'))["serviceCategories"]
 
@@ -95,18 +84,17 @@ class TestIndexingDocuments(BaseApplicationTestWithIndex):
 
         assert_response_status(response, 200)
 
-    def test_should_raise_400_on_bad_doc_type(self, default_service):
+    def test_should_raise_400_on_bad_doc_type(self, service):
         response = self.client.put(
-            make_search_api_url(default_service, type_name='some-bad-type'),
-            data=json.dumps(default_service),
+            make_search_api_url(service, type_name='some-bad-type'),
+            data=json.dumps(service),
             content_type='application/json')
 
         assert_response_status(response, 400)
 
 
 class TestDeleteById(BaseApplicationTestWithIndex):
-    def test_should_delete_service_by_id(self, default_service):
-        service = default_service
+    def test_should_delete_service_by_id(self, service):
         self.client.put(
             make_search_api_url(service),
             data=json.dumps(service),
@@ -114,22 +102,22 @@ class TestDeleteById(BaseApplicationTestWithIndex):
         )
 
         with self.app.app_context():
-            search_service.refresh('index-to-create')
+            search_service.refresh('test-index')
         response = self.client.delete(make_search_api_url(service),)
 
-        data = get_json_from_response(response)
+        data = response.json
         assert_response_status(response, 200)
         assert data['message']['found'] is True
 
         response = self.client.get(make_search_api_url(service),)
-        data = get_json_from_response(response)
+        data = response.json
         assert_response_status(response, 404)
         assert data['error']['found'] is False
 
     def test_should_return_404_if_no_service(self):
         response = self.client.delete(
-            '/index-to-create/delete/100')
+            '/test-index/delete/100')
 
-        data = get_json_from_response(response)
+        data = response.json
         assert_response_status(response, 404)
         assert data['error']['found'] is False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,29 @@
 
-
 import pytest
-import os
+import pathlib
 import json
 
 import app.mapping
 
 
-with open(os.path.join(os.path.dirname(__file__), '../mappings/services.json')) as f:
-    _services_mapping_definition = json.load(f)
+mappings_dir = (pathlib.Path(__file__).parent / "../mappings").resolve()
+services_mappings = (
+    "services",
+)
+
+
+@pytest.fixture(scope="module", params=services_mappings)
+def services_mapping_file_name_and_path(request):
+    return (request.param, mappings_dir / f"{request.param}.json")
 
 
 @pytest.fixture()
-def services_mapping():
+def services_mapping(services_mapping_file_name_and_path):
     """Fixture that provides an Elastic Search mapping, for unit testing functions that expect to be passed one."""
-    return app.mapping.Mapping(_services_mapping_definition, 'services')
+    services_mapping_dict = json.loads(services_mapping_file_name_and_path[1].read_text())
+    return app.mapping.Mapping(services_mapping_dict, "services")
+
+
 def make_service(**kwargs):
     service = {
         "id": "id",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 
 import pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import app.mapping
 
 mappings_dir = (pathlib.Path(__file__).parent / "../mappings").resolve()
 services_mappings = (
-    "services",
+    "services-g-cloud-10",
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,36 +2,43 @@
 
 import pytest
 import os
-import mock
 import json
 
 import app.mapping
-from tests.app.helpers import make_standard_service
 
 
 with open(os.path.join(os.path.dirname(__file__), '../mappings/services.json')) as f:
     _services_mapping_definition = json.load(f)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def services_mapping():
     """Fixture that provides an Elastic Search mapping, for unit testing functions that expect to be passed one."""
     return app.mapping.Mapping(_services_mapping_definition, 'services')
+def make_service(**kwargs):
+    service = {
+        "id": "id",
+        "lot": "LoT",
+        "serviceName": "serviceName",
+        "serviceDescription": "serviceDescription",
+        "serviceBenefits": "serviceBenefits",
+        "serviceFeatures": "serviceFeatures",
+        "serviceCategories": ["serviceCategories"],
+        "supplierName": "Supplier Name",
+        "publicSectorNetworksTypes": ["PSN", "PNN"],
+    }
+
+    service.update(kwargs)
+
+    return {
+        "document": service
+    }
 
 
-@pytest.fixture(scope="module")
-def services_mapping_definition():
-    """Fixture that patches load_mapping_definition, to ensure our mapping fixture is used wherever an index is
-    created."""
-    with mock.patch('app.mapping.load_mapping_definition') as mock_definition_loader:
-        mock_definition_loader.return_value = _services_mapping_definition
-        yield mock_definition_loader.return_value
-
-
-@pytest.fixture(scope="function")
-def default_service():
+@pytest.fixture()
+def service():
     """
     A fixture for a service such as might be indexed in the Search API.
     :return: dict
     """
-    return make_standard_service()
+    return make_service()


### PR DESCRIPTION
This PR changes our tests to use the services mapping `services-g-cloud-10`.

To acheive this I refactored the tests so that the services mapping used in tests is defined in one place in `tests/conftest.py`; this should also mean that it is much easier to update the tests in future.

I also did some generic refactoring, including renaming some things so that their intended uses are clearer. A lot of these changes are part of the work to [prepare search-api for Elasticsearch 6](https://trello.com/c/BlYurEoJ/418-prepare-search-api-for-elasticsearch-6).