### PR TITLE
Remove extraneous helper methods and move helpers to base of tests

### DIFF
--- a/tests/app/services/test_query_builder.py
+++ b/tests/app/services/test_query_builder.py
@@ -6,7 +6,7 @@ from app.main.services.query_builder import (
     filter_clause,
 )
 from werkzeug.datastructures import MultiDict
-from tests.app.helpers import build_query_params
+from tests.helpers import build_query_params
 
 
 def test_should_have_correct_root_element(services_mapping):

--- a/tests/app/services/test_search_service.py
+++ b/tests/app/services/test_search_service.py
@@ -3,7 +3,7 @@ import mock
 
 from elasticsearch import TransportError
 
-from ..helpers import BaseApplicationTestWithIndex
+from tests.helpers import BaseApplicationTestWithIndex
 
 
 class TestCoreSearchAndAggregate(BaseApplicationTestWithIndex):

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -7,7 +7,7 @@ import pytest
 from flask import json
 from elasticsearch.exceptions import ConnectionError
 
-from .helpers import BaseApplicationTest
+from tests.helpers import BaseApplicationTest
 
 
 class TestApplication(BaseApplicationTest):

--- a/tests/app/views/test_admin.py
+++ b/tests/app/views/test_admin.py
@@ -1,23 +1,23 @@
 from flask import json
 
-from tests.app.helpers import BaseApplicationTest, assert_response_status
+from tests.helpers import BaseApplicationTest
 
 
 class TestSearchIndexes(BaseApplicationTest):
     def test_should_be_able_create_and_delete_index(self):
         response = self.create_index()
-        assert_response_status(response, 200)
+        assert response.status_code == 200
         assert response.json["message"] == "acknowledged"
 
         response = self.client.get('/test-index')
-        assert_response_status(response, 200)
+        assert response.status_code == 200
 
         response = self.client.delete('/test-index')
-        assert_response_status(response, 200)
+        assert response.status_code == 200
         assert response.json["message"] == "acknowledged"
 
         response = self.client.get('/test-index')
-        assert_response_status(response, 404)
+        assert response.status_code == 404
 
     def test_should_be_able_to_create_aliases(self):
         self.create_index()
@@ -26,7 +26,7 @@ class TestSearchIndexes(BaseApplicationTest):
             "target": "test-index"
         }), content_type="application/json")
 
-        assert_response_status(response, 200)
+        assert response.status_code == 200
         assert response.json["message"] == "acknowledged"
 
     def test_should_not_be_able_to_delete_aliases(self):
@@ -38,7 +38,7 @@ class TestSearchIndexes(BaseApplicationTest):
 
         response = self.client.delete('/index-alias')
 
-        assert_response_status(response, 400)
+        assert response.status_code == 400
         assert response.json["error"] == "Cannot delete alias 'index-alias'"
 
     def test_should_not_be_able_to_delete_index_with_alias(self):
@@ -50,7 +50,7 @@ class TestSearchIndexes(BaseApplicationTest):
 
         response = self.client.delete('/test-index')
 
-        assert_response_status(response, 400)
+        assert response.status_code == 400
         assert (
             response.json["error"] ==
             "Index 'test-index' is aliased as 'index-alias' and cannot be deleted"
@@ -62,7 +62,7 @@ class TestSearchIndexes(BaseApplicationTest):
             "target": "test-index"
         }), content_type="application/json")
 
-        assert_response_status(response, 404)
+        assert response.status_code == 404
         assert response.json["error"].startswith(
             'index_not_found_exception: no such index')
 
@@ -73,7 +73,7 @@ class TestSearchIndexes(BaseApplicationTest):
             "target": "test-index"
         }), content_type="application/json")
 
-        assert_response_status(response, 400)
+        assert response.status_code == 400
 
         expected_string = (
             'invalid_alias_name_exception: Invalid alias name [test-index], an index exists with the same name '
@@ -94,7 +94,7 @@ class TestSearchIndexes(BaseApplicationTest):
             "target": "test-index-2"
         }), content_type="application/json")
 
-        assert_response_status(response, 200)
+        assert response.status_code == 200
         status = self.client.get('/_all').json["status"]
         assert status['test-index']['aliases'] == []
         assert status['test-index-2']['aliases'] == ['index-alias']
@@ -104,19 +104,19 @@ class TestSearchIndexes(BaseApplicationTest):
 
         response = self.create_index(expect_success=False)
 
-        assert_response_status(response, 400)
+        assert response.status_code == 400
         assert response.json["error"].startswith("index_already_exists_exception:")
 
     def test_should_not_be_able_delete_index_twice(self):
         self.create_index()
         self.client.delete('/test-index')
         response = self.client.delete('/test-index')
-        assert_response_status(response, 404)
+        assert response.status_code == 404
         assert response.json["error"] == 'index_not_found_exception: no such index (test-index)'
 
     def test_should_return_404_if_no_index(self):
         response = self.client.get('/index-does-not-exist')
-        assert_response_status(response, 404)
+        assert response.status_code == 404
         assert (
             response.json["error"] ==
             "index_not_found_exception: no such index (index-does-not-exist)"
@@ -128,5 +128,5 @@ class TestSearchIndexes(BaseApplicationTest):
             "mapping": "some-bad-mapping"
         }), content_type="application/json")
 
-        assert_response_status(response, 400)
+        assert response.status_code == 400
         assert response.json["error"] == "Mapping definition named 'some-bad-mapping' not found."

--- a/tests/app/views/test_meta.py
+++ b/tests/app/views/test_meta.py
@@ -1,5 +1,5 @@
 import json
-from ..helpers import BaseApplicationTestWithIndex
+from tests.helpers import BaseApplicationTestWithIndex
 
 
 class TestMeta(BaseApplicationTestWithIndex):

--- a/tests/app/views/test_search_queries.py
+++ b/tests/app/views/test_search_queries.py
@@ -3,7 +3,7 @@ from flask import json
 import pytest
 
 from app import create_app
-from ..helpers import setup_authorization, make_service
+from tests.helpers import setup_authorization, make_service
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/tests/app/views/test_status.py
+++ b/tests/app/views/test_status.py
@@ -3,7 +3,7 @@ import json
 import mock
 from elasticsearch import TransportError
 
-from ..helpers import BaseApplicationTest
+from tests.helpers import BaseApplicationTest
 
 
 class TestStatus(BaseApplicationTest):

--- a/tests/app/views/test_update.py
+++ b/tests/app/views/test_update.py
@@ -4,7 +4,7 @@ from flask import json
 from urllib3.exceptions import NewConnectionError
 
 from app.main.services import search_service
-from tests.app.helpers import BaseApplicationTestWithIndex, make_search_api_url, assert_response_status
+from tests.helpers import BaseApplicationTestWithIndex, make_search_api_url
 
 
 class TestIndexingDocuments(BaseApplicationTestWithIndex):
@@ -19,12 +19,12 @@ class TestIndexingDocuments(BaseApplicationTestWithIndex):
             data=json.dumps(service),
             content_type='application/json')
 
-        assert_response_status(response, 200)
+        assert response.status_code == 200
 
         with self.app.app_context():
             search_service.refresh('test-index')
         response = self.client.get('/test-index')
-        assert_response_status(response, 200)
+        assert response.status_code == 200
         assert response.json["status"]["num_docs"] == 1
 
     @mock.patch('app.main.views.update.index')
@@ -38,7 +38,7 @@ class TestIndexingDocuments(BaseApplicationTestWithIndex):
             data=json.dumps(service),
             content_type='application/json'
         )
-        assert_response_status(response, 500)
+        assert response.status_code == 500
         current_app.logger.error.assert_called_once_with(
             f'API response error: ": {self.EXAMPLE_CONNECTION_ERROR}" Unexpected status code: "{error_status_code}"'
         )
@@ -51,7 +51,7 @@ class TestIndexingDocuments(BaseApplicationTestWithIndex):
             data=json.dumps(service),
             content_type='application/json')
 
-        assert_response_status(response, 200)
+        assert response.status_code == 200
 
     def test_should_index_a_document_with_extra_fields(self, service):
         service.get('document', service.get('service'))["randomField"] = "some random"
@@ -61,7 +61,7 @@ class TestIndexingDocuments(BaseApplicationTestWithIndex):
             data=json.dumps(service),
             content_type='application/json')
 
-        assert_response_status(response, 200)
+        assert response.status_code == 200
 
     def test_should_index_a_document_with_incorrect_types(self, service):
         service.get('document', service.get('service'))["serviceName"] = 123
@@ -71,7 +71,7 @@ class TestIndexingDocuments(BaseApplicationTestWithIndex):
             data=json.dumps(service),
             content_type='application/json')
 
-        assert_response_status(response, 200)
+        assert response.status_code == 200
 
     def test_should_index_a_document_with_no_service_types(self, service):
         service.get('document', service.get('service'))["serviceName"] = 123
@@ -82,7 +82,7 @@ class TestIndexingDocuments(BaseApplicationTestWithIndex):
             data=json.dumps(service),
             content_type='application/json')
 
-        assert_response_status(response, 200)
+        assert response.status_code == 200
 
     def test_should_raise_400_on_bad_doc_type(self, service):
         response = self.client.put(
@@ -90,7 +90,7 @@ class TestIndexingDocuments(BaseApplicationTestWithIndex):
             data=json.dumps(service),
             content_type='application/json')
 
-        assert_response_status(response, 400)
+        assert response.status_code == 400
 
 
 class TestDeleteById(BaseApplicationTestWithIndex):
@@ -106,12 +106,12 @@ class TestDeleteById(BaseApplicationTestWithIndex):
         response = self.client.delete(make_search_api_url(service),)
 
         data = response.json
-        assert_response_status(response, 200)
+        assert response.status_code == 200
         assert data['message']['found'] is True
 
         response = self.client.get(make_search_api_url(service),)
         data = response.json
-        assert_response_status(response, 404)
+        assert response.status_code == 404
         assert data['error']['found'] is False
 
     def test_should_return_404_if_no_service(self):
@@ -119,5 +119,5 @@ class TestDeleteById(BaseApplicationTestWithIndex):
             '/test-index/delete/100')
 
         data = response.json
-        assert_response_status(response, 404)
+        assert response.status_code == 404
         assert data['error']['found'] is False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,13 @@
-
 import pytest
 import pathlib
 import json
 
 import app.mapping
 
+from .helpers import make_service, services_mappings
+
 
 mappings_dir = (pathlib.Path(__file__).parent / "../mappings").resolve()
-services_mappings = (
-    "services-g-cloud-10",
-)
 
 
 @pytest.fixture(scope="module", params=services_mappings)
@@ -22,26 +20,6 @@ def services_mapping(services_mapping_file_name_and_path):
     """Fixture that provides an Elastic Search mapping, for unit testing functions that expect to be passed one."""
     services_mapping_dict = json.loads(services_mapping_file_name_and_path[1].read_text())
     return app.mapping.Mapping(services_mapping_dict, "services")
-
-
-def make_service(**kwargs):
-    service = {
-        "id": "id",
-        "lot": "LoT",
-        "serviceName": "serviceName",
-        "serviceDescription": "serviceDescription",
-        "serviceBenefits": "serviceBenefits",
-        "serviceFeatures": "serviceFeatures",
-        "serviceCategories": ["serviceCategories"],
-        "supplierName": "Supplier Name",
-        "publicSectorNetworksTypes": ["PSN", "PNN"],
-    }
-
-    service.update(kwargs)
-
-    return {
-        "document": service
-    }
 
 
 @pytest.fixture()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,9 +6,9 @@ from werkzeug.datastructures import MultiDict
 from app import create_app
 from app import elasticsearch_client
 
-from ..conftest import (
-    make_service,
-    services_mappings,
+
+services_mappings = (
+    "services-g-cloud-10",
 )
 
 
@@ -88,17 +88,21 @@ def make_search_api_url(data, type_name='services'):
     return '/test-index/{}/{}'.format(type_name, str(data.get('document', data.get('service'))['id']))
 
 
-def assert_response_status(response, expected_status):
-    __tracebackhide__ = True
-    assert response.status_code == expected_status, "Expected {} response; got {}. {}".format(
-        expected_status, response.status_code, response.get_data(as_text=True)
-    )
+def make_service(**kwargs):
+    service = {
+        "id": "id",
+        "lot": "LoT",
+        "serviceName": "serviceName",
+        "serviceDescription": "serviceDescription",
+        "serviceBenefits": "serviceBenefits",
+        "serviceFeatures": "serviceFeatures",
+        "serviceCategories": ["serviceCategories"],
+        "supplierName": "Supplier Name",
+        "publicSectorNetworksTypes": ["PSN", "PNN"],
+    }
 
+    service.update(kwargs)
 
-def create_services(number_of_services):
-    services = []
-    for i in range(number_of_services):
-        service = make_service(id=str(i))
-        services.append(service)
-
-    return services
+    return {
+        "document": service
+    }


### PR DESCRIPTION
* Move `tests.app.helpers` > `tests.helpers`
* Remove `assert_response_status` in favour of normal assert statement
* Consolidate common setup method of TestSearchEndpoint and TestSearchResultsOrdering
  * Create BaseSearchTestWithServices
  * Remove `create_services` now only used in the consolidated setup
* Move `services_mapping` and `make_services` to `tests.helpers`