### PR TITLE
Elasticsearch 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,14 @@ language: python
 python:
   - "3.6"
 env:
-  - ES_VERSION=5.6.13 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
-install:
+  - ES_VERSION=5.6.13
+  - ES_VERSION=6.7.0
+before_install:
+  - ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
   - wget ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch > /dev/null &
+install:
   - make requirements-dev
 script:
   - PYTEST_ARGS='--cov=app --cov-report=term-missing' make test

--- a/app/main/services/query_builder.py
+++ b/app/main/services/query_builder.py
@@ -59,16 +59,18 @@ def highlight_clause(mapping):
     highlights = {
         "encoder": "html",
         "pre_tags": ["<mark class='search-result-highlighted-text'>"],
-        "post_tags": ["</mark>"]
-    }
-    highlights["fields"] = {}
+        "post_tags": ["</mark>"],
 
-    # Get all fields searched and allow non-matches to a max of the searchSummary limit
-    for field in mapping.fields_by_prefix.get(mapping.text_search_field_prefix, ()):
-        highlights["fields"]["_".join((mapping.text_search_field_prefix, field))] = {
-            "number_of_fragments": 0,
-            "no_match_size": 500
+        # we always want the whole field, the longest field is the description
+        # which is limited to 500 chars
+        "number_of_fragments": 0,
+        "no_match_size": 500,
+
+        # Get all fields searched
+        "fields": {
+            f"{mapping.text_search_field_prefix}_*": {},
         }
+    }
 
     return highlights
 

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -63,7 +63,7 @@ def delete_index(index_name):
 def fetch_by_id(index_name, doc_type, document_id):
     try:
         with logged_duration_for_external_request('es'):
-            res = es.get(index_name, document_id, doc_type)
+            res = es.get(index=index_name, doc_type=doc_type, id=document_id)
         return res, 200
     except TransportError as e:
         return _get_an_error_message(e), e.status_code
@@ -72,7 +72,7 @@ def fetch_by_id(index_name, doc_type, document_id):
 def delete_by_id(index_name, doc_type, document_id):
     try:
         with logged_duration_for_external_request('es'):
-            res = es.delete(index_name, doc_type, document_id)
+            res = es.delete(index=index_name, doc_type=doc_type, id=document_id)
         return res, 200
     except TransportError as e:
         return _get_an_error_message(e), e.status_code

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -1,5 +1,5 @@
 from elasticsearch import TransportError
-from flask import current_app, url_for
+from flask import current_app, escape, url_for
 
 from dmutils.timing import logged_duration_for_external_request
 
@@ -120,7 +120,7 @@ def _page_404_response(requested_page):
     ), 404
 
 
-def core_search_and_aggregate(index_name, doc_type, query_args, search=False, aggregations=[]):
+def core_search_and_aggregate(index_name, doc_type, query_args, search=False, aggregations=[]):  # noqa: C901
     try:
         mapping = app.mapping.get_mapping(index_name, doc_type)
         page_size = int(current_app.config['DM_SEARCH_PAGE_SIZE'])
@@ -133,6 +133,19 @@ def core_search_and_aggregate(index_name, doc_type, query_args, search=False, ag
             res = es.search(index=index_name, doc_type=doc_type, body=constructed_query, **es_search_kwargs)
 
         results = convert_es_results(mapping, res, query_args)
+
+        # WORKAROUND: In Elasticsearch 6 the default highlighter will only return the first sentence if the
+        # highlighter finds no terms to mark. This hack basically makes sure that the always get the full
+        # service description in this case. See https://github.com/elastic/elasticsearch/issues/41066.
+        # Should be fixed in > v6.7.2 :fingers_crossed:.
+        for document in results["documents"]:
+            if "highlight" not in document:
+                break
+            if len(document["highlight"]["serviceDescription"][0]) < len(document["serviceDescription"]):
+                escaped_description = escape(document["serviceDescription"])
+                # escape doesn't escape / but Elasticsearch does
+                escaped_description = escaped_description.translate({ord("/"): "&#x2F;"})
+                document["highlight"]["serviceDescription"] = [escaped_description]
 
         def url_for_search(**kwargs):
             return url_for('.search', index_name=index_name, doc_type=doc_type, _external=True, **kwargs)

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,5 +7,5 @@ itsdangerous==0.24 # pyup: ignore
 git+https://github.com/alphagov/digitalmarketplace-utils.git@46.3.1#egg=digitalmarketplace-utils==46.3.1
 
 # Elasticsearch 5.0
-elasticsearch==5.5.3 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
+elasticsearch==6.3.1 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
 Flask-Elasticsearch==0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ itsdangerous==0.24 # pyup: ignore
 git+https://github.com/alphagov/digitalmarketplace-utils.git@46.3.1#egg=digitalmarketplace-utils==46.3.1
 
 # Elasticsearch 5.0
-elasticsearch==5.5.3 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
+elasticsearch==6.3.1 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
 Flask-Elasticsearch==0.2.5
 
 ## The following requirements were added by pip freeze:

--- a/tests/app/services/test_query_builder.py
+++ b/tests/app/services/test_query_builder.py
@@ -8,6 +8,8 @@ from app.main.services.query_builder import (
 from werkzeug.datastructures import MultiDict
 from tests.helpers import build_query_params
 
+import re
+
 
 def test_should_have_correct_root_element(services_mapping):
     assert "query" in construct_query(services_mapping, build_query_params())
@@ -224,7 +226,7 @@ def test_highlight_block_contains_correct_fields(services_mapping, example):
     query = construct_query(services_mapping, build_query_params(keywords="some keywords"))
 
     assert "highlight" in query
-    assert 'dmtext_' + example in query["highlight"]["fields"], example
+    assert any(re.match(field, "dmtext_" + example) for field in query["highlight"]["fields"]), example
 
 
 class TestFieldFilters(object):

--- a/tests/app/views/test_admin.py
+++ b/tests/app/views/test_admin.py
@@ -105,7 +105,7 @@ class TestSearchIndexes(BaseApplicationTest):
         response = self.create_index(expect_success=False)
 
         assert response.status_code == 400
-        assert response.json["error"].startswith("index_already_exists_exception:")
+        assert "already_exists_exception" in response.json["error"]
 
     def test_should_not_be_able_delete_index_twice(self):
         self.create_index()

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -287,6 +287,14 @@ class TestHighlightedService(BaseApplicationTestWithIndex):
                 ),
                 lot="long-text",
             ))
+            put(make_service(
+                id="4",
+                serviceDescription=(
+                    "This service description has <em>2</em> sentences. "
+                    "There is HTML in <b>each</b> sentence."
+                ),
+                lot="two-sentences",
+            ))
 
             search_service.refresh("test-index")
 
@@ -353,6 +361,13 @@ class TestHighlightedService(BaseApplicationTestWithIndex):
             ==
             got
         )
+        got = [doc for doc in search_results if doc["id"] == "4"][0]["highlight"]["serviceDescription"][0]
+        assert (
+            "This service description has &lt;em&gt;2&lt;&#x2F;em&gt; sentences. "
+            "There is HTML in &lt;b&gt;each&lt;&#x2F;b&gt; sentence."
+            ==
+            got
+        )
 
         search_results = self.client.get("test-index/services/search?q=fox").json["documents"]
         got = search_results[0]["highlight"]["serviceDescription"][0]
@@ -360,6 +375,17 @@ class TestHighlightedService(BaseApplicationTestWithIndex):
             "The &lt;em&gt;quick&lt;&#x2F;em&gt; brown "
             "<mark class='search-result-highlighted-text'>fox</mark> "
             "jumped over the &lt;em&gt;lazy&lt;&#x2F;em&gt; dog."
+            ==
+            got
+        )
+
+        search_results = self.client.get("test-index/services/search?q=sentence").json["documents"]
+        got = [doc for doc in search_results if doc["id"] == "4"][0]["highlight"]["serviceDescription"][0]
+        assert (
+            "This service description has &lt;em&gt;2&lt;&#x2F;em&gt; "
+            "<mark class='search-result-highlighted-text'>sentences</mark>. "
+            "There is HTML in &lt;b&gt;each&lt;&#x2F;b&gt; "
+            "<mark class='search-result-highlighted-text'>sentence</mark>."
             ==
             got
         )

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -340,8 +340,9 @@ class TestHighlightedService(BaseApplicationTestWithIndex):
             "of a 100 character string.\n"
             * 5
         )
-        assert len(expected) == len(got)
-        assert expected == got
+        # Some highlighters strip trailing space from the field text
+        assert len(got) == len(expected) or len(got) == len(expected) - 1
+        assert got == expected or got == expected.strip()
 
     def test_html_in_highlighted_service_description_is_always_escaped(self):
         search_results = self.client.get("test-index/services/search").json["documents"]

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -312,48 +312,53 @@ class TestHighlightedService(BaseApplicationTestWithIndex):
     )
     def test_highlighted_service_description_always_contains_full_service_description(self, search_query):
         search_results = self.client.get(f"/test-index/services/search{search_query}").json["documents"]
-        long_text = [doc for doc in search_results if doc["id"] == "3"][0]["highlight"]["serviceDescription"][0]
-        assert len(long_text) == 500
+        got = [doc for doc in search_results if doc["id"] == "3"][0]["highlight"]["serviceDescription"][0]
+        expected = (
+            "This service description has 500 characters. "
+            "It is made of 5 repetitions of a 100 character string.\n"
+            * 5
+        )
+        assert 500 == len(got)
+        assert expected == got
 
     def test_search_terms_are_marked_in_highlighted_service_description(self):
         search_results = self.client.get("test-index/services/search?q=storing").json["documents"]
-        marked_text = search_results[0]["highlight"]["serviceDescription"][0]
+        got = search_results[0]["highlight"]["serviceDescription"][0]
         assert (
-            marked_text
-            ==
             "Accessing, <mark class='search-result-highlighted-text'>storing</mark> and retaining email."
+            ==
+            got
         )
 
     def test_highlighted_service_description_can_be_longer_than_500_characters_if_marked(self):
         search_results = self.client.get("/test-index/services/search?q=repetitions").json["documents"]
-        long_text = [doc for doc in search_results if doc["id"] == "3"][0]["highlight"]["serviceDescription"][0]
-        assert (
-            long_text
-            ==
+        got = [doc for doc in search_results if doc["id"] == "3"][0]["highlight"]["serviceDescription"][0]
+        expected = (
             "This service description has 500 characters. "
             "It is made of 5 "
             "<mark class='search-result-highlighted-text'>repetitions</mark> "
             "of a 100 character string.\n"
             * 5
         )
-        assert len(long_text) > 500
+        assert len(expected) == len(got)
+        assert expected == got
 
     def test_html_in_highlighted_service_description_is_always_escaped(self):
         search_results = self.client.get("test-index/services/search").json["documents"]
-        escaped_text = [doc for doc in search_results if doc["id"] == "2"][0]["highlight"]["serviceDescription"][0]
+        got = [doc for doc in search_results if doc["id"] == "2"][0]["highlight"]["serviceDescription"][0]
         assert (
-            escaped_text
-            ==
             "The &lt;em&gt;quick&lt;&#x2F;em&gt; brown fox "
             "jumped over the &lt;em&gt;lazy&lt;&#x2F;em&gt; dog."
+            ==
+            got
         )
 
         search_results = self.client.get("test-index/services/search?q=fox").json["documents"]
-        escaped_text = search_results[0]["highlight"]["serviceDescription"][0]
+        got = search_results[0]["highlight"]["serviceDescription"][0]
         assert (
-            escaped_text
-            ==
             "The &lt;em&gt;quick&lt;&#x2F;em&gt; brown "
             "<mark class='search-result-highlighted-text'>fox</mark> "
             "jumped over the &lt;em&gt;lazy&lt;&#x2F;em&gt; dog."
+            ==
+            got
         )

--- a/tests/app/views/test_update.py
+++ b/tests/app/views/test_update.py
@@ -107,7 +107,7 @@ class TestDeleteById(BaseApplicationTestWithIndex):
 
         data = response.json
         assert response.status_code == 200
-        assert data['message']['found'] is True
+        assert data["message"]["result"] == "deleted"
 
         response = self.client.get(make_search_api_url(service),)
         data = response.json
@@ -118,9 +118,8 @@ class TestDeleteById(BaseApplicationTestWithIndex):
         response = self.client.delete(
             '/test-index/services/not-an-id-that-exists')
 
-        data = response.json
         assert response.status_code == 404
-        assert data['error']['found'] is False
+        assert response.json["error"]["result"] == "not_found"
 
     def test_should_raise_400_on_bad_doc_type(self, service):
         response = self.client.delete(


### PR DESCRIPTION
PR to [make search-api work with Elasticsearch 6](https://trello.com/c/BlYurEoJ/418-prepare-search-api-for-elasticsearch-6).

Tested with Elasticsearch 6.7.0.

Note that this merges into `elasticsearch-6` (not `master`).

Includes workaround for https://github.com/elastic/elasticsearch/issues/41066, but hopefully it won't be needed!