### PR TITLE
Fix bug where alias for .kibana-1 would cause 500

### DIFF
--- a/app/main/views/meta.py
+++ b/app/main/views/meta.py
@@ -32,7 +32,11 @@ def root():
     with logged_duration_for_external_request('es'):
         es_alias_json = es.cat.aliases(format='json')
 
-    aliases = {info['alias']: info['index'] for info in es_alias_json}
+    aliases = {
+        info['alias']: info['index']
+        for info in es_alias_json
+        if not info['index'].startswith('.')
+    }
     for alias_name, index_name in aliases.items():
         for type_name in types_by_index_name[index_name]:
             links.append({

--- a/tests/app/views/test_meta.py
+++ b/tests/app/views/test_meta.py
@@ -1,27 +1,55 @@
+
 import json
 from tests.helpers import BaseApplicationTestWithIndex
 
+from app import elasticsearch_client
+
 
 class TestMeta(BaseApplicationTestWithIndex):
-    def test_home(self):
+
+    def setup(self):
+        super().setup()
         with self.app.app_context():
             self.client.put('/index-alias', data=json.dumps({
                 "type": "alias",
                 "target": "test-index",
             }), content_type="application/json")
 
-            response = self.client.get('/')
-            response_data = json.loads(response.get_data())
+            elasticsearch_client.indices.create(
+                index=".dot-index",
+                body=json.dumps({"mappings": {"mapping": {}}})
+            )
+            self.client.put('/dot-index-alias', data=json.dumps({
+                "type": "alias",
+                "target": ".dot-index",
+            }), content_type="application/json")
 
-            assert response.status_code == 200
-            assert {"href": "http://localhost/test-index/services/search",
-                    "rel": "query.gdm.index",
-                    } in response_data['links']
-            assert {"href": "http://localhost/index-alias/services/search",
-                    "rel": "query.gdm.alias",
-                    } in response_data['links']
-            assert frozenset(response_data['field-mappings']) == frozenset((
-                'services',
-                'briefs-digital-outcomes-and-specialists-2',
-                'services-g-cloud-10',
-            ))
+    def teardown(self):
+        with self.app.app_context():
+            elasticsearch_client.indices.delete(".dot-index")
+            elasticsearch_client.indices.delete_alias(name="index-alias", index="test-index")
+        super().teardown()
+
+    def test_home(self):
+        response = self.client.get('/')
+        response_data = response.json
+
+        assert response.status_code == 200
+        assert {"href": "http://localhost/test-index/services/search",
+                "rel": "query.gdm.index",
+                } in response_data['links']
+        assert {"href": "http://localhost/index-alias/services/search",
+                "rel": "query.gdm.alias",
+                } in response_data['links']
+        assert frozenset(response_data['field-mappings']) == frozenset((
+            'services',
+            'briefs-digital-outcomes-and-specialists-2',
+            'services-g-cloud-10',
+        ))
+
+    def test_exludes_dot_indices_with_aliases(self):
+
+        response = self.client.get('/')
+
+        assert response.status_code == 200
+        assert b"dot-index" not in response.data


### PR DESCRIPTION
Fixes issue detailed on [Trello].

It turns out the 500s weren't caused by any change in our code, but a change in the default indices of the Elasticsearch instance provided by Aiven.

In the past there has been an index `.kibana-1`, which we have ignored in `app.main.views.root`, but in the new instance there is also an alias for this index, which our logic wasn't expecting and couldn't handle.

This PR adds a test for the expected behaviour and a fix.

[Trello]: https://trello.com/c/KW5wwTnv