### PR TITLE
Remove Elasticsearch 5 Travis CI check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "3.6"
 env:
-  - ES_VERSION=5.6.13
   - ES_VERSION=6.7.0
 before_install:
   - ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz


### PR DESCRIPTION
Ticket: https://trello.com/c/GCgD9vuB/781-remove-es5-travis-check-for-search-api

We no longer use Elasticsearch 5 anywhere, so we don't need this check.