### PR TITLE
docker base image: bump to 4.5.4 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:4.4.4
+FROM digitalmarketplace/base-api:4.5.4

--- a/default.nix
+++ b/default.nix
@@ -27,7 +27,7 @@ in (with args; {
     ] ++ pkgs.stdenv.lib.optionals withLocalES [
       ((import ./es.nix) (with pkgs; {
         inherit stdenv makeWrapper writeScript;
-        elasticsearch = elasticsearch5;
+        elasticsearch = elasticsearch6-oss;
         homePath = (toString (./.)) + "/local_es_home";
       }))
     ];


### PR DESCRIPTION
https://trello.com/c/PyDaRXEj

To get us https://github.com/alphagov/digitalmarketplace-docker-base/pull/56

Also sneak in a little nix fix.