### PR TITLE
use Flask-gzip to compress all possible responses

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,7 @@ from flask import Flask
 import json
 from config import config as configs
 from flask_elasticsearch import FlaskElasticsearch
+from flask_gzip import Gzip
 
 from dmutils.flask_init import init_app, api_error_handlers
 
@@ -48,5 +49,9 @@ def create_app(config_name):
     application.register_blueprint(main_blueprint)
 
     gds_metrics.init_app(application)
+
+    # because the search api doesn't return any values in its bodies we would consider "secrets", we should be
+    # able to safely gzip all response bodies without concerns about BREACH et al.
+    Gzip(application, minimum_size=1024)
 
     return application

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -9,3 +9,4 @@ git+https://github.com/alphagov/digitalmarketplace-utils.git@48.0.2#egg=digitalm
 # Elasticsearch 5.0
 elasticsearch==6.3.1 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
 Flask-Elasticsearch==0.2.5
+Flask-gzip==0.2 # pyup: <0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,13 +10,14 @@ git+https://github.com/alphagov/digitalmarketplace-utils.git@48.0.2#egg=digitalm
 # Elasticsearch 5.0
 elasticsearch==6.3.1 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
 Flask-Elasticsearch==0.2.5
+Flask-gzip==0.2 # pyup: <0.3
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 blinker==1.4
-boto3==1.9.205
-botocore==1.12.205
-certifi==2019.6.16
+boto3==1.9.228
+botocore==1.12.228
+certifi==2019.9.11
 cffi==1.12.3
 chardet==3.0.4
 Click==7.0
@@ -24,14 +25,14 @@ contextlib2==0.5.5
 cryptography==2.3.1
 defusedxml==0.6.0
 docopt==0.6.2
-docutils==0.14
+docutils==0.15.2
 Flask-Login==0.4.1
 Flask-Script==2.0.6
 Flask-WTF==0.14.2
 fleep==1.0.1
 future==0.17.1
 gds-metrics==0.2.0
-govuk-country-register==0.4.0
+govuk-country-register==0.5.0
 idna==2.8
 Jinja2==2.10.1
 jmespath==0.9.4
@@ -51,6 +52,6 @@ s3transfer==0.2.1
 six==1.12.0
 unicodecsv==0.14.1
 urllib3==1.25.3
-Werkzeug==0.15.5
+Werkzeug==0.15.6
 workdays==1.4
 WTForms==2.2.1


### PR DESCRIPTION
This is an initial fix attempt for https://trello.com/c/Kd4qas51

It's not got any of the bells & whistles mentioned in the card involving "safe" headers or anything: the idea is to be able to release something that will let us know whether compressing our responses has _any_ effect on our envoy issues.

If we take this further, we can easily subclass this `Gzip` middleware to add e.g. header-controlled options and stick it in `-utils`.