### PR TITLE
Revert "bump docker base image to 7.0.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:7.0.0
+FROM digitalmarketplace/base-api:6.1.0


### PR DESCRIPTION
Reverts alphagov/digitalmarketplace-search-api#235