### PR TITLE
Revert "Revert "bump docker base image to 7.0.0""

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:6.1.0
+FROM digitalmarketplace/base-api:7.0.0


### PR DESCRIPTION
This didn't turn out to be the culprit after all - the release process just caused a dodgy ES broker to give us dodgy creds.