### PR TITLE
switch from direct flask_gzip use to DMGzipMiddleware

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,8 +2,8 @@ from flask import Flask
 import json
 from config import config as configs
 from flask_elasticsearch import FlaskElasticsearch
-from flask_gzip import Gzip
 
+from dmutils.flask import DMGzipMiddleware
 from dmutils.flask_init import init_app, api_error_handlers
 
 elasticsearch_client = FlaskElasticsearch()
@@ -52,6 +52,6 @@ def create_app(config_name):
 
     # because the search api doesn't return any values in its bodies we would consider "secrets", we should be
     # able to safely gzip all response bodies without concerns about BREACH et al.
-    Gzip(application, minimum_size=1024)
+    DMGzipMiddleware(application, compress_by_default=True)
 
     return application

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -4,9 +4,8 @@
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.0.2#egg=digitalmarketplace-utils==48.0.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.6.0#egg=digitalmarketplace-utils==48.6.0
 
 # Elasticsearch 5.0
 elasticsearch==6.3.1 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
 Flask-Elasticsearch==0.2.5
-Flask-gzip==0.2 # pyup: <0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,27 +5,27 @@
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.0.2#egg=digitalmarketplace-utils==48.0.2
+git+https://github.com/alphagov/digitalmarketplace-utils.git@48.6.0#egg=digitalmarketplace-utils==48.6.0
 
 # Elasticsearch 5.0
 elasticsearch==6.3.1 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
 Flask-Elasticsearch==0.2.5
-Flask-gzip==0.2 # pyup: <0.3
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0
 blinker==1.4
-boto3==1.9.228
-botocore==1.12.228
+boto3==1.9.237
+botocore==1.12.237
 certifi==2019.9.11
 cffi==1.12.3
 chardet==3.0.4
 Click==7.0
-contextlib2==0.5.5
+contextlib2==0.6.0
 cryptography==2.3.1
 defusedxml==0.6.0
 docopt==0.6.2
 docutils==0.15.2
+Flask-gzip==0.2
 Flask-Login==0.4.1
 Flask-Script==2.0.6
 Flask-WTF==0.14.2
@@ -51,7 +51,7 @@ requests==2.22.0
 s3transfer==0.2.1
 six==1.12.0
 unicodecsv==0.14.1
-urllib3==1.25.3
+urllib3==1.25.6
 Werkzeug==0.15.6
 workdays==1.4
 WTForms==2.2.1

--- a/tests/app/test_application.py
+++ b/tests/app/test_application.py
@@ -54,10 +54,10 @@ class TestApplication(BaseApplicationTest):
 class TestGzip(BaseApplicationTestWithIndex):
     def setup(self):
         super().setup()
-        for c in "abcdefg":
+        for c in "abcdefghijklmnopqrstuvwxyz1234567890":
             # create a bunch of indexes with quite long names so we definitely have a response from the "/" route
             # that is > the minimum gzipped size limit
-            self.create_index(index_name=f"test-{c*128}")
+            self.create_index(index_name=f"test-{c*180}")
 
     def test_gzip(self):
         response = self.client.get('/', headers={"Accept-Encoding": "gzip"})


### PR DESCRIPTION
Note here I had to manually set `requirements.txt` back to werkzeug `0.15.6` because pip was insistent on bumping it to `0.16.0` despite our restriction in `-utils`. Though it _doesn't_ complain about unmet dependencies with this package set despite my ineterference, so I guess it's fine...? Not sure what's going on here but, y'know, pip sucks, so it doesn't surprise me tremendously.