### PR TITLE
Bump docker base image to 7.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:7.1.0
+FROM digitalmarketplace/base-api:7.2.0


### PR DESCRIPTION
https://trello.com/c/1ch9wfEa

Shouldn't be any difference, but we need to use the latest image to get security bumps...