### PR TITLE
Update docker image to move to supervisor4 and remove python2 dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:7.2.0
+FROM digitalmarketplace/base-api:8.0.0


### PR DESCRIPTION
As per https://trello.com/c/tr4LFyYP/104-move-to-supervisor-4-using-python-3