### PR TITLE
Add Python 3.7 and 3.8 checks to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
 env:
   - ES_VERSION=6.7.0
 before_install:

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -4,7 +4,7 @@
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.6.0#egg=digitalmarketplace-utils==48.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
 
 # Elasticsearch 5.0
 elasticsearch==6.3.1 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,22 +5,22 @@
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@48.6.0#egg=digitalmarketplace-utils==48.6.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
 
 # Elasticsearch 5.0
 elasticsearch==6.3.1 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
 Flask-Elasticsearch==0.2.5
 
 ## The following requirements were added by pip freeze:
-asn1crypto==0.24.0
+asn1crypto==1.2.0
 blinker==1.4
-boto3==1.9.237
-botocore==1.12.237
+boto3==1.10.23
+botocore==1.13.23
 certifi==2019.9.11
-cffi==1.12.3
+cffi==1.13.2
 chardet==3.0.4
 Click==7.0
-contextlib2==0.6.0
+contextlib2==0.6.0.post1
 cryptography==2.3.1
 defusedxml==0.6.0
 docopt==0.6.2
@@ -30,28 +30,28 @@ Flask-Login==0.4.1
 Flask-Script==2.0.6
 Flask-WTF==0.14.2
 fleep==1.0.1
-future==0.17.1
+future==0.18.2
 gds-metrics==0.2.0
 govuk-country-register==0.5.0
 idna==2.8
-Jinja2==2.10.1
+Jinja2==2.10.3
 jmespath==0.9.4
 mailchimp3==3.0.6
 MarkupSafe==1.1.1
 monotonic==1.5
-notifications-python-client==5.3.0
+notifications-python-client==5.4.0
 odfpy==1.4.0
 prometheus-client==0.2.0
 pycparser==2.19
 PyJWT==1.7.1
 python-dateutil==2.8.0
 python-json-logger==0.1.11
-pytz==2019.2
+pytz==2019.3
 requests==2.22.0
 s3transfer==0.2.1
-six==1.12.0
+six==1.13.0
 unicodecsv==0.14.1
-urllib3==1.25.6
-Werkzeug==0.15.6
+urllib3==1.25.7
+Werkzeug==0.16.0
 workdays==1.4
 WTForms==2.2.1


### PR DESCRIPTION
https://trello.com/c/GsDBHBo7/135-switch-on-python-37-and-38-travis-checks-to-check-potential-dependency-problems-before-upgrade

- Bumps utils only - other libraries not used
- Adds 3.7 and 3.8 to Travis config

(Also bumps Werkzeug, superseding https://github.com/alphagov/digitalmarketplace-search-api/pull/243)