### PR TITLE
192-cause-additionalchecks-to-always-be-run-regardless-of-ignore-dependencies-on-status-endpoint

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -4,7 +4,7 @@
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@51.0.0#egg=digitalmarketplace-utils==51.0.0
 
 # Elasticsearch 5.0
 elasticsearch==6.3.1 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 Flask==1.0.4 # pyup: >=1.0.0,<1.1.0
 itsdangerous==0.24 # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.1#egg=digitalmarketplace-utils==50.0.1
+git+https://github.com/alphagov/digitalmarketplace-utils.git@51.0.0#egg=digitalmarketplace-utils==51.0.0
 
 # Elasticsearch 5.0
 elasticsearch==6.3.1 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
@@ -14,9 +14,9 @@ Flask-Elasticsearch==0.2.5
 ## The following requirements were added by pip freeze:
 asn1crypto==1.2.0
 blinker==1.4
-boto3==1.10.23
-botocore==1.13.23
-certifi==2019.9.11
+boto3==1.10.40
+botocore==1.13.40
+certifi==2019.11.28
 cffi==1.13.2
 chardet==3.0.4
 Click==7.0
@@ -39,7 +39,7 @@ jmespath==0.9.4
 mailchimp3==3.0.6
 MarkupSafe==1.1.1
 monotonic==1.5
-notifications-python-client==5.4.0
+notifications-python-client==5.4.1
 odfpy==1.4.0
 prometheus-client==0.2.0
 pycparser==2.19


### PR DESCRIPTION
Update search api to use new utils including causing run of additional_checks regardless of `include-dependencies` parameter

See:
https://trello.com/c/B2GfZgfO/192-cause-additionalchecks-to-always-be-run-regardless-of-ignore-dependencies-on-status-endpoint
https://github.com/alphagov/digitalmarketplace-utils/blob/master/CHANGELOG.md#5100