### PR TITLE
Bump docker base image to 9.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:8.0.0
+FROM digitalmarketplace/base-api:ris-node-bump-move-to-fe

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:ris-node-bump-move-to-fe
+FROM digitalmarketplace/base-api:9.0.0


### PR DESCRIPTION
Keeping up to date with https://trello.com/c/25rCohcs, this should also shed node from the app's image.