### PR TITLE
bump utils version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@
 Flask==1.0.4        # pyup: >=1.0.0,<1.1.0
 itsdangerous==1.1.0  # pyup: ignore
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.5.0#egg=digitalmarketplace-utils==51.5.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.3.0#egg=digitalmarketplace-utils==52.3.0
 
 # Elasticsearch 5.0
 elasticsearch==6.3.1 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ click==7.0                # via flask
 contextlib2==0.6.0.post1  # via digitalmarketplace-utils
 cryptography==2.3.1       # via digitalmarketplace-utils
 defusedxml==0.6.0         # via odfpy
-git+https://github.com/alphagov/digitalmarketplace-utils.git@51.5.0#egg=digitalmarketplace-utils==51.5.0  # via -r requirements.in
+git+https://github.com/alphagov/digitalmarketplace-utils.git@52.3.0#egg=digitalmarketplace-utils==52.3.0  # via -r requirements.in
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore
 elasticsearch==6.3.1      # via -r requirements.in, flask-elasticsearch


### PR DESCRIPTION
part of https://trello.com/c/PTdD5lEh/102-our-logs-show-paas-instance-guid-but-not-paas-instance-index  
I don't think the breaking change should effect this app: https://github.com/alphagov/digitalmarketplace-utils/blob/master/CHANGELOG.md#5200﻿
