### PR TITLE
bump docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM digitalmarketplace/base-api:9.2.0
+FROM digitalmarketplace/base-api:9.4.0


### PR DESCRIPTION
bump docker version to pick up changes from alphagov/digitalmarketplace-docker-base#74