### PR TITLE
Remove workarounds for elasticsearch highlighting bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.7"
   - "3.8"
 env:
-  - ES_VERSION=6.7.0
+  - ES_VERSION=6.8.9
 before_install:
   - ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
   - wget ${ES_DOWNLOAD_URL}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This command will install dependencies and start the app.
 By default, the app will be served at [http://127.0.0.1:5009](http://127.0.0.1:5009).
 
 ### Local Elasticsearch setup
-Install version 6.x of [elasticsearch](http://www.elasticsearch.org/), ideally 6.7/6.8 which is what we run on live systems.
+Install version 6.x of [elasticsearch](http://www.elasticsearch.org/), ideally 6.8 which is what we run on live systems.
 
 ```
 brew update

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -318,8 +318,9 @@ class TestHighlightedService(BaseApplicationTestWithIndex):
             "It is made of 5 repetitions of a 100 character string.\n"
             * 5
         )
-        assert 500 == len(got)
-        assert expected == got
+        # Some highlighters strip trailing space from the field text
+        assert len(got) == len(expected) or len(got) == len(expected) - 1
+        assert got == expected or got == expected.strip()
 
     def test_search_terms_are_marked_in_highlighted_service_description(self):
         search_results = self.client.get("test-index/services/search?q=storing").json["documents"]

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -287,6 +287,14 @@ class TestHighlightedService(BaseApplicationTestWithIndex):
                 ),
                 lot="long-text",
             ))
+            put(make_service(
+                id="4",
+                serviceDescription=(
+                    "This service description has <em>2</em> sentences. "
+                    "There is HTML in <b>each</b> sentence."
+                ),
+                lot="two-sentences",
+            ))
 
             search_service.refresh("test-index")
 
@@ -354,6 +362,13 @@ class TestHighlightedService(BaseApplicationTestWithIndex):
             ==
             got
         )
+        got = [doc for doc in search_results if doc["id"] == "4"][0]["highlight"]["serviceDescription"][0]
+        assert (
+            "This service description has &lt;em&gt;2&lt;&#x2F;em&gt; sentences. "
+            "There is HTML in &lt;b&gt;each&lt;&#x2F;b&gt; sentence."
+            ==
+            got
+        )
 
         search_results = self.client.get("test-index/services/search?q=fox").json["documents"]
         got = search_results[0]["highlight"]["serviceDescription"][0]
@@ -361,6 +376,17 @@ class TestHighlightedService(BaseApplicationTestWithIndex):
             "The &lt;em&gt;quick&lt;&#x2F;em&gt; brown "
             "<mark class='search-result-highlighted-text'>fox</mark> "
             "jumped over the &lt;em&gt;lazy&lt;&#x2F;em&gt; dog."
+            ==
+            got
+        )
+
+        search_results = self.client.get("test-index/services/search?q=sentence").json["documents"]
+        got = [doc for doc in search_results if doc["id"] == "4"][0]["highlight"]["serviceDescription"][0]
+        assert (
+            "This service description has &lt;em&gt;2&lt;&#x2F;em&gt; "
+            "<mark class='search-result-highlighted-text'>sentences</mark>. "
+            "There is HTML in &lt;b&gt;each&lt;&#x2F;b&gt; "
+            "<mark class='search-result-highlighted-text'>sentence</mark>."
             ==
             got
         )

--- a/tests/app/views/test_search.py
+++ b/tests/app/views/test_search.py
@@ -287,14 +287,6 @@ class TestHighlightedService(BaseApplicationTestWithIndex):
                 ),
                 lot="long-text",
             ))
-            put(make_service(
-                id="4",
-                serviceDescription=(
-                    "This service description has <em>2</em> sentences. "
-                    "There is HTML in <b>each</b> sentence."
-                ),
-                lot="two-sentences",
-            ))
 
             search_service.refresh("test-index")
 
@@ -361,13 +353,6 @@ class TestHighlightedService(BaseApplicationTestWithIndex):
             ==
             got
         )
-        got = [doc for doc in search_results if doc["id"] == "4"][0]["highlight"]["serviceDescription"][0]
-        assert (
-            "This service description has &lt;em&gt;2&lt;&#x2F;em&gt; sentences. "
-            "There is HTML in &lt;b&gt;each&lt;&#x2F;b&gt; sentence."
-            ==
-            got
-        )
 
         search_results = self.client.get("test-index/services/search?q=fox").json["documents"]
         got = search_results[0]["highlight"]["serviceDescription"][0]
@@ -375,17 +360,6 @@ class TestHighlightedService(BaseApplicationTestWithIndex):
             "The &lt;em&gt;quick&lt;&#x2F;em&gt; brown "
             "<mark class='search-result-highlighted-text'>fox</mark> "
             "jumped over the &lt;em&gt;lazy&lt;&#x2F;em&gt; dog."
-            ==
-            got
-        )
-
-        search_results = self.client.get("test-index/services/search?q=sentence").json["documents"]
-        got = [doc for doc in search_results if doc["id"] == "4"][0]["highlight"]["serviceDescription"][0]
-        assert (
-            "This service description has &lt;em&gt;2&lt;&#x2F;em&gt; "
-            "<mark class='search-result-highlighted-text'>sentences</mark>. "
-            "There is HTML in &lt;b&gt;each&lt;&#x2F;b&gt; "
-            "<mark class='search-result-highlighted-text'>sentence</mark>."
             ==
             got
         )


### PR DESCRIPTION
Revert workarounds for https://github.com/elastic/elasticsearch/issues/41066 which has now been fixed in the version of elasticsearch we are running on PaaS.

I have also manually checked highlighting is still working e.g. 
![Screenshot 2020-07-28 at 12 22 55](https://user-images.githubusercontent.com/1764158/88659647-4dc74700-d0cd-11ea-9c84-45151aef4ed6.png)
