### PR TITLE
Remove local DM_SEARCH_PAGE_SIZE configuration

### DIFF
--- a/config.py
+++ b/config.py
@@ -42,7 +42,6 @@ class Test(Config):
 class Development(Config):
     DEBUG = True
     DM_PLAIN_TEXT_LOGS = True
-    DM_SEARCH_PAGE_SIZE = 5
 
     DM_SEARCH_API_AUTH_TOKENS = 'myToken'
 


### PR DESCRIPTION
I don't think there is a need to limit the number of results per page locally, it's better to have it closer to what will be seen on production where possible.