### PR TITLE
Support Elasticsearch 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ python:
   - "3.8"
   - "3.9"
 env:
-  - ES_VERSION=6.8.9
+  - ES_VERSION=7.9.3
 before_install:
-  - ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+  - ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz
   - wget ${ES_DOWNLOAD_URL}
-  - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
+  - tar -xzf elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch > /dev/null &
 install:
   - make requirements-dev

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -63,7 +63,7 @@ def delete_index(index_name):
 def fetch_by_id(index_name, doc_type, document_id):
     try:
         with logged_duration_for_external_request('es'):
-            res = es.get(index=index_name, doc_type=doc_type, id=document_id)
+            res = es.get(index=index_name, id=document_id)
         return res, 200
     except TransportError as e:
         return _get_an_error_message(e), e.status_code
@@ -72,7 +72,7 @@ def fetch_by_id(index_name, doc_type, document_id):
 def delete_by_id(index_name, doc_type, document_id):
     try:
         with logged_duration_for_external_request('es'):
-            res = es.delete(index=index_name, doc_type=doc_type, id=document_id)
+            res = es.delete(index=index_name, id=document_id)
         return res, 200
     except TransportError as e:
         return _get_an_error_message(e), e.status_code
@@ -84,7 +84,6 @@ def index(index_name, doc_type, document, document_id):
             es.index(
                 index=index_name,
                 id=document_id,
-                doc_type=doc_type,
                 body=document)
             return "acknowledged", 200
     except TransportError as e:
@@ -130,7 +129,9 @@ def core_search_and_aggregate(index_name, doc_type, query_args, search=False, ag
         es_search_kwargs = {'search_type': 'dfs_query_then_fetch'} if search else {}
         constructed_query = construct_query(mapping, query_args, aggregations, page_size)
         with logged_duration_for_external_request('es'):
-            res = es.search(index=index_name, doc_type=doc_type, body=constructed_query, **es_search_kwargs)
+            res = es.search(
+                index=index_name, body=constructed_query, **es_search_kwargs
+            )
 
         results = convert_es_results(mapping, res, query_args)
 
@@ -176,7 +177,6 @@ def core_search_and_aggregate(index_name, doc_type, query_args, search=False, ag
                 with logged_duration_for_external_request('es'):
                     result_count = es.count(
                         index=index_name,
-                        doc_type=doc_type,
                         body=body
                     )["count"]
             except TransportError as e:

--- a/app/main/services/search_service.py
+++ b/app/main/services/search_service.py
@@ -217,9 +217,8 @@ def _get_an_error_message(exception):
         root_cause = error['root_cause'][0]
         type = root_cause.get('type', '<unknown type>')
         reason = root_cause.get('reason', '<unknown reason>')
-        index = root_cause.get('index', '<no index>')
 
-        return '{}: {} ({})'.format(type, reason, index)
+        return f"{type}: {reason}"
 
     except (KeyError, IndexError):
         pass

--- a/app/mapping.py
+++ b/app/mapping.py
@@ -82,9 +82,14 @@ def get_mapping(index_name, document_type):
         raise MappingNotFound("Document type '{}' is not valid in index '{}' - no mapping found.".format(
             document_type, index_name))
 
-    # In ES <=5, there may be multiple mapping types per document type (kind-of) - this is confusing, but going
-    # away, see <https://www.elastic.co/guide/en/elasticsearch/reference/5.6/removal-of-types.html>. For us,
-    # document_type === mapping_type, and there will be only one per index.
+    # In ES 7 mapping types are being removed, so document types are no longer relevant.
+    # However our API still uses them in URLs and is expecting a 400 to be raised in case
+    # the wrong document type is specified.
+    if mapping_data["mappings"]["_meta"]["doc_type"] != document_type:
+        raise MappingNotFound(
+            f"Document type '{document_type}' is not valid in index '{index_name}' - not returning mapping."
+        )
+
     return Mapping(mapping_data, mapping_type=document_type)
 
 

--- a/app/mapping.py
+++ b/app/mapping.py
@@ -36,7 +36,7 @@ class Mapping(object):
             (prefix, maybe_name_seq[0])
             for prefix, *maybe_name_seq in (
                 full_field_name.split("_", 1)
-                for full_field_name in sorted(self.definition['mappings'][self.mapping_type]['properties'].keys())
+                for full_field_name in sorted(self.definition['mappings']['properties'].keys())
             )
             if maybe_name_seq  # maybe_name_seq would be an empty seq if no underscores were found, discard them
         )
@@ -60,10 +60,10 @@ class Mapping(object):
         }
 
         self.transform_fields = tuple(
-            self.definition['mappings'][mapping_type].get('_meta', {}).get('transformations', {})
+            self.definition['mappings'].get('_meta', {}).get('transformations', {})
         )
 
-        self.sort_clause = self.definition['mappings'][mapping_type].get('_meta', {}).get('dm_sort_clause', ["_score"])
+        self.sort_clause = self.definition['mappings'].get('_meta', {}).get('dm_sort_clause', ["_score"])
 
 
 def get_mapping(index_name, document_type):
@@ -71,7 +71,7 @@ def get_mapping(index_name, document_type):
         # es.indices.get_mapping has a key for the index name, regardless of any alias we may be going via, so rather
         # than use index_name, we access the one and only value in the dictionary using next(iter).
         with logged_duration_for_external_request('es'):
-            mapping_data = next(iter(es.indices.get_mapping(index=index_name, doc_type=document_type).values()))
+            mapping_data = next(iter(es.indices.get_mapping(index=index_name).values()))
     except NotFoundError as e:
         if e.error == "type_missing_exception":
             raise MappingNotFound("Document type '{}' is not valid in index '{}' - no mapping found.".format(

--- a/app/mapping.py
+++ b/app/mapping.py
@@ -12,7 +12,6 @@ from dmutils.timing import logged_duration_for_external_request
 
 from app import elasticsearch_client as es
 
-
 _mapping_files = None  # dict(name: filespec)
 
 

--- a/mappings/briefs-digital-outcomes-and-specialists-2.json
+++ b/mappings/briefs-digital-outcomes-and-specialists-2.json
@@ -8,7 +8,6 @@
         "stemming_analyzer": {
           "tokenizer": "standard",
           "filter": [
-            "standard",
             "lowercase",
             "possessive_english_stemmer",
             "light_english_stemmer"

--- a/mappings/briefs-digital-outcomes-and-specialists-2.json
+++ b/mappings/briefs-digital-outcomes-and-specialists-2.json
@@ -49,6 +49,7 @@
       "_": "DO NOT UPDATE BY HAND",
       "version": "11.0.0",
       "generated_from_framework": "digital-outcomes-and-specialists-2",
+      "doc_type": "briefs",
       "generated_by": "/Users/brendanbutler/digitalmarketplace/digitalmarketplace-frameworks/scripts/generate-search-config.py",
       "generated_time": "2018-03-13T14:53:51.783965",
       "dm_sort_clause": [

--- a/mappings/briefs-digital-outcomes-and-specialists-2.json
+++ b/mappings/briefs-digital-outcomes-and-specialists-2.json
@@ -45,183 +45,181 @@
     }
   },
   "mappings": {
-    "briefs": {
-      "_meta": {
-        "_": "DO NOT UPDATE BY HAND",
-        "version": "11.0.0",
-        "generated_from_framework": "digital-outcomes-and-specialists-2",
-        "generated_by": "/Users/brendanbutler/digitalmarketplace/digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2018-03-13T14:53:51.783965",
-        "dm_sort_clause": [
-          "sortonly_statusOrder",
-          {
-            "sortonly_publishedAt": "desc"
-          },
-          "sortonly_idHash"
-        ],
-        "transformations": [
-          {
-            "hash_to": {
-              "field": "id",
-              "target_field": "idHash"
-            }
-          },
-          {
-            "set_conditionally": {
-              "field": "status",
-              "target_field": "statusOpenClosed",
-              "any_of": [
-                "live"
-              ],
-              "set_value": "open"
-            }
-          },
-          {
-            "set_conditionally": {
-              "field": "status",
-              "target_field": "statusOpenClosed",
-              "any_of": [
-                "awarded",
-                "cancelled",
-                "closed",
-                "unsuccessful"
-              ],
-              "set_value": "closed"
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "status",
-              "target_field": "statusOrder",
-              "any_of": [
-                "live"
-              ],
-              "append_value": [
-                0
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "status",
-              "target_field": "statusOrder",
-              "any_of": [
-                "closed",
-                "awarded",
-                "cancelled",
-                "unsuccessful"
-              ],
-              "append_value": [
-                1
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "status",
-              "target_field": "statusOrder",
-              "any_of": [
-                "draft",
-                "withdrawn"
-              ],
-              "append_value": [
-                2
-              ]
-            }
+    "_meta": {
+      "_": "DO NOT UPDATE BY HAND",
+      "version": "11.0.0",
+      "generated_from_framework": "digital-outcomes-and-specialists-2",
+      "generated_by": "/Users/brendanbutler/digitalmarketplace/digitalmarketplace-frameworks/scripts/generate-search-config.py",
+      "generated_time": "2018-03-13T14:53:51.783965",
+      "dm_sort_clause": [
+        "sortonly_statusOrder",
+        {
+          "sortonly_publishedAt": "desc"
+        },
+        "sortonly_idHash"
+      ],
+      "transformations": [
+        {
+          "hash_to": {
+            "field": "id",
+            "target_field": "idHash"
           }
-        ]
-      },
-      "dynamic": "strict",
-      "properties": {
-        "dmtext_id": {
-          "type": "keyword"
         },
-        "sortonly_idHash": {
-          "type": "keyword"
+        {
+          "set_conditionally": {
+            "field": "status",
+            "target_field": "statusOpenClosed",
+            "any_of": [
+              "live"
+            ],
+            "set_value": "open"
+          }
         },
-        "dmfilter_lot": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
+        {
+          "set_conditionally": {
+            "field": "status",
+            "target_field": "statusOpenClosed",
+            "any_of": [
+              "awarded",
+              "cancelled",
+              "closed",
+              "unsuccessful"
+            ],
+            "set_value": "closed"
+          }
         },
-        "dmtext_lot": {
-          "type": "keyword"
+        {
+          "append_conditionally": {
+            "field": "status",
+            "target_field": "statusOrder",
+            "any_of": [
+              "live"
+            ],
+            "append_value": [
+              0
+            ]
+          }
         },
-        "dmagg_lot": {
-          "type": "keyword"
+        {
+          "append_conditionally": {
+            "field": "status",
+            "target_field": "statusOrder",
+            "any_of": [
+              "closed",
+              "awarded",
+              "cancelled",
+              "unsuccessful"
+            ],
+            "append_value": [
+              1
+            ]
+          }
         },
-        "dmtext_withdrawnAt": {
-          "type": "keyword"
-        },
-        "dmtext_publishedAt": {
-          "type": "keyword"
-        },
-        "sortonly_publishedAt": {
-          "type": "date"
-        },
-        "dmtext_applicationsClosedAt": {
-          "type": "keyword"
-        },
-        "dmtext_clarificationQuestionsClosedAt": {
-          "type": "keyword"
-        },
-        "dmtext_cancelledAt": {
-          "type": "keyword"
-        },
-        "dmtext_unsuccessfulAt": {
-          "type": "keyword"
-        },
-        "dmtext_awardedBriefResponseId": {
-          "type": "keyword"
-        },
-        "dmtext_organisation": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_title": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_specialistRole": {
-          "type": "text"
-        },
-        "dmfilter_specialistRole": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmtext_summary": {
-          "term_vector": "with_positions_offsets",
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_essentialRequirements": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_niceToHaveRequirements": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_status": {
-          "type": "keyword"
-        },
-        "dmfilter_status": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_statusOpenClosed": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "sortonly_statusOrder": {
-          "type": "byte"
-        },
-        "dmfilter_location": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmtext_location": {
-          "type": "text"
+        {
+          "append_conditionally": {
+            "field": "status",
+            "target_field": "statusOrder",
+            "any_of": [
+              "draft",
+              "withdrawn"
+            ],
+            "append_value": [
+              2
+            ]
+          }
         }
+      ]
+    },
+    "dynamic": "strict",
+    "properties": {
+      "dmtext_id": {
+        "type": "keyword"
+      },
+      "sortonly_idHash": {
+        "type": "keyword"
+      },
+      "dmfilter_lot": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmtext_lot": {
+        "type": "keyword"
+      },
+      "dmagg_lot": {
+        "type": "keyword"
+      },
+      "dmtext_withdrawnAt": {
+        "type": "keyword"
+      },
+      "dmtext_publishedAt": {
+        "type": "keyword"
+      },
+      "sortonly_publishedAt": {
+        "type": "date"
+      },
+      "dmtext_applicationsClosedAt": {
+        "type": "keyword"
+      },
+      "dmtext_clarificationQuestionsClosedAt": {
+        "type": "keyword"
+      },
+      "dmtext_cancelledAt": {
+        "type": "keyword"
+      },
+      "dmtext_unsuccessfulAt": {
+        "type": "keyword"
+      },
+      "dmtext_awardedBriefResponseId": {
+        "type": "keyword"
+      },
+      "dmtext_organisation": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_title": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_specialistRole": {
+        "type": "text"
+      },
+      "dmfilter_specialistRole": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmtext_summary": {
+        "term_vector": "with_positions_offsets",
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_essentialRequirements": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_niceToHaveRequirements": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_status": {
+        "type": "keyword"
+      },
+      "dmfilter_status": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_statusOpenClosed": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "sortonly_statusOrder": {
+        "type": "byte"
+      },
+      "dmfilter_location": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmtext_location": {
+        "type": "text"
       }
     }
   }

--- a/mappings/services-g-cloud-10.json
+++ b/mappings/services-g-cloud-10.json
@@ -8,7 +8,6 @@
         "stemming_analyzer": {
           "tokenizer": "standard",
           "filter": [
-            "standard",
             "lowercase",
             "possessive_english_stemmer",
             "light_english_stemmer"

--- a/mappings/services-g-cloud-10.json
+++ b/mappings/services-g-cloud-10.json
@@ -45,830 +45,828 @@
     }
   },
   "mappings": {
-    "services": {
-      "_meta": {
-        "_": "DO NOT UPDATE BY HAND",
-        "version": "15.0.0",
-        "generated_from_framework": "g-cloud-10",
-        "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2019-03-06T09:18:21.596263",
-        "dm_sort_clause": [
-          "_score",
-          {
-            "sortonly_serviceIdHash": "desc"
-          }
-        ],
-        "transformations": [
-          {
-            "hash_to": {
-              "field": "id",
-              "target_field": "serviceIdHash"
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Accounts payable",
-                "Accounts receivable",
-                "Asset management",
-                "Billing and invoicing",
-                "Budgeting",
-                "Contract management",
-                "Debt collection",
-                "Enterprise resource planning (ERP)",
-                "Expense management, expense reporting",
-                "Farming and farm management",
-                "Financial compliance",
-                "Financial management",
-                "Financial risk management",
-                "Land management",
-                "Payment gateway",
-                "Payroll",
-                "Portfolio analysis",
-                "Procurement",
-                "Purchasing",
-                "Revenue cycle management",
-                "Tax management",
-                "Other accounting and finance services"
-              ],
-              "append_value": [
-                "Accounting and finance"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Analytics",
-                "Business intelligence",
-                "Data mining, analysis tools and analytics",
-                "Data visualisation",
-                "Reporting and dashboards"
-              ],
-              "append_value": [
-                "Analytics and business intelligence"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Anti-spam and CAPTCHA",
-                "Audit tools",
-                "Authentication, identity and access management",
-                "Encryption",
-                "Log management",
-                "Remote access",
-                "Secure content and threat management",
-                "Security risk management"
-              ],
-              "append_value": [
-                "Application security"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Blogging",
-                "Booking, scheduling and diary management",
-                "Calendar",
-                "Case management",
-                "Content management system (CMS)",
-                "Content storage and sharing",
-                "Email and secure email",
-                "Enterprise social networking",
-                "File sending and file sharing",
-                "Idea management",
-                "Instant messaging (IM) and chat",
-                "Meeting management",
-                "Online forum or community",
-                "Online meetings",
-                "Presentations and slides (office productivity)",
-                "Project collaboration",
-                "Spreadsheets (office productivity)",
-                "Task management",
-                "Webinars",
-                "Word processing (office productivity)",
-                "Workflow"
-              ],
-              "append_value": [
-                "Collaborative working"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Accessibility checking",
-                "Blogging",
-                "Content management system (CMS)",
-                "Design",
-                "Diagram and wireframe",
-                "Digital publishing",
-                "Online forums",
-                "Photography and multimedia",
-                "Presentations and slides (office productivity)",
-                "Social networking",
-                "Word processing (office productivity)"
-              ],
-              "append_value": [
-                "Creative, design and publishing"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Call centre",
-                "Constituent engagement",
-                "Contact management",
-                "CRM system",
-                "Customer helpdesk (service desk)",
-                "Customer service and support",
-                "Feedback and reviews management",
-                "Forms and surveys",
-                "Live chat",
-                "Partner relationship management (PRM)",
-                "Virtual agents",
-                "Other CRM services"
-              ],
-              "append_value": [
-                "Customer relationship management (CRM)"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Backup, recovery and archival",
-                "Content management system (CMS)",
-                "Document management",
-                "Electronic data interchange (EDI)",
-                "Electronic signatures",
-                "File sending and sharing",
-                "File storage",
-                "Image management and picture archiving"
-              ],
-              "append_value": [
-                "Electronic document and records management (EDRM)"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Assisted living monitoring",
-                "Chiropractic",
-                "Clinical decision support",
-                "Clinical trial management",
-                "Dental",
-                "Electronic medical records",
-                "Healthcare analytics",
-                "Healthcare management",
-                "Home healthcare",
-                "Long-term care",
-                "Medical billing",
-                "Medical imaging",
-                "Medical lab",
-                "Medical practice",
-                "Medical scheduling and booking",
-                "Mental health",
-                "Optometry",
-                "Patient case management, care pathway management",
-                "Pharmacy",
-                "Pharmacy management",
-                "Physical therapy"
-              ],
-              "append_value": [
-                "Healthcare"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Applicant tracking",
-                "Benefits administration",
-                "Culture management",
-                "Employee scheduling",
-                "Employee self-service",
-                "Enterprise social networking",
-                "Examination (applicant testing)",
-                "Holiday planning and absence management",
-                "Payroll",
-                "Performance management",
-                "Recruitment",
-                "Salary",
-                "Talent (retention management)",
-                "Time and expense tracking",
-                "Training",
-                "Workforce analytics",
-                "Workforce management"
-              ],
-              "append_value": [
-                "Human resources and employee management"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "API connectors and interface engines",
-                "Application lifecycle management",
-                "Authentication, identity and access management",
-                "Backup, recovery and archival",
-                "Calendar",
-                "Call accounting",
-                "Call centre",
-                "Configuration and patch management",
-                "Desktop as a Service",
-                "Electronic data interchange (EDI)",
-                "Email and secure email",
-                "Fault management, monitoring and alerting",
-                "Fax",
-                "File sending and file sharing",
-                "File storage",
-                "Forms and surveys",
-                "Geographic information systems and mapping",
-                "Instant messaging (IM) and chat",
-                "Interactive voice response (IVR)",
-                "IT asset management",
-                "Licence management",
-                "Machine learning and artificial intelligence",
-                "Mobile device management",
-                "Natural language and speech processing",
-                "Network services (DNS)",
-                "Online meetings",
-                "Password management",
-                "Performance management",
-                "Post (mailing services)",
-                "Presentations and slides (office productivity)",
-                "Printing",
-                "Security",
-                "SMS",
-                "Spreadsheets (office productivity)",
-                "Systems monitoring",
-                "Telecoms expense management",
-                "Telephony (including VOIP and SIP connectivity)",
-                "Unified communications",
-                "Video conferencing",
-                "Virtual private network (VPN)",
-                "Word processing (office productivity)",
-                "Other information and communications technology (ICT) services"
-              ],
-              "append_value": [
-                "Information and communications technology (ICT)"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Electronic discovery (legal)",
-                "Law enforcement",
-                "Law practice management",
-                "Legal billing",
-                "Legal calendar",
-                "Legal case management",
-                "Legal document management",
-                "Trust accounting"
-              ],
-              "append_value": [
-                "Legal and enforcement"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Advertising",
-                "Affiliate marketing",
-                "Behavioural targeting",
-                "Brand management",
-                "Campaign management",
-                "Community management",
-                "Contextual marketing",
-                "Display advertising",
-                "Email marketing",
-                "Forms and surveys",
-                "Marketing analytics",
-                "Marketing automation",
-                "Marketing data",
-                "Mobile marketing",
-                "Online display advertising",
-                "Personalisation and behavioral targeting",
-                "Public relations",
-                "Search marketing",
-                "Social marketing",
-                "Social media marketing",
-                "Social media monitoring",
-                "Webinars",
-                "Other marketing services"
-              ],
-              "append_value": [
-                "Marketing"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Applications",
-                "Building information modelling (BIM)",
-                "Business management",
-                "Business performance management",
-                "Business process management (BPM)",
-                "Business process modelling (BPM)",
-                "Business transformation and organisational change management",
-                "Carbon, energy and sustainability management",
-                "Complex event processing",
-                "Contract management",
-                "Digital asset management",
-                "Digital signatures",
-                "Enterprise resource planning (ERP)",
-                "Facility management",
-                "Field service management",
-                "Governance, risk management and compliance (GRC)",
-                "Inventory management",
-                "Order management",
-                "Procurement",
-                "Product lifecycle management",
-                "Scheduling and appointments",
-                "Supply chain management",
-                "Visitor management",
-                "Workflow",
-                "Other operations management services"
-              ],
-              "append_value": [
-                "Operations management"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Agile project management and issue tracking",
-                "Professional services automation (PSA)",
-                "Project management",
-                "Project portfolio management (PPM)",
-                "Task management",
-                "Time and expense tracking"
-              ],
-              "append_value": [
-                "Project management and planning"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Configure, price and quote (CPQ)",
-                "eCommerce and shopping cart",
-                "Payment gateway",
-                "Recurring billing and subscription management",
-                "Sales and operations planning",
-                "Sales intelligence tracking",
-                "Sales performance management",
-                "Other sales services"
-              ],
-              "append_value": [
-                "Sales"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Academic",
-                "Alumni management",
-                "Asynchronous learning",
-                "Campus management",
-                "Classroom management",
-                "eLearning",
-                "Examination or applicant testing",
-                "Library automation",
-                "Library management",
-                "Online courses",
-                "Online grading",
-                "School accounting",
-                "School administration",
-                "Student management",
-                "Synchronous learning"
-              ],
-              "append_value": [
-                "Schools, education and libraries"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Accessibility",
-                "Agile project management and issue tracking",
-                "Bug tracking",
-                "Build tools",
-                "Code generation",
-                "Development tools",
-                "Form building",
-                "Integrated development environment (IDE)",
-                "Mobile development",
-                "Search",
-                "Source code management",
-                "Testing and optimisation",
-                "Usability",
-                "Version control",
-                "Website builder"
-              ],
-              "append_value": [
-                "Software development tools"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Airport management",
-                "Aviation maintenance",
-                "Distribution",
-                "Fleet management",
-                "Fleet tracking",
-                "Freight management",
-                "Inventory management",
-                "Marine",
-                "Shipping",
-                "Transportation dispatch",
-                "Trucking solutions",
-                "Warehouse management",
-                "Other transport and logistics services"
-              ],
-              "append_value": [
-                "Transport and logistics"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "setupAndMigrationService",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Planning"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "setupAndMigrationService",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Setup and migration"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "QAAndTesting",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Quality assurance and performance testing"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "securityTesting",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Security services"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "training",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Training"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "ongoingSupport",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Ongoing support"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "emailOrTicketingSupport",
-              "target_field": "emailOrTicketingSupport",
-              "any_of": [
-                "yes_extra_cost"
-              ],
-              "append_value": [
-                "yes"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "webChatSupport",
-              "target_field": "webChatSupport",
-              "any_of": [
-                "yes_extra_cost"
-              ],
-              "append_value": [
-                "yes"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "onsiteSupport",
-              "target_field": "onsiteSupport",
-              "any_of": [
-                "yes_extra_cost"
-              ],
-              "append_value": [
-                "yes"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "dataStorageAndProcessingLocations",
-              "target_field": "dataStorageAndProcessingLocations",
-              "any_of": [
-                "uk"
-              ],
-              "append_value": [
-                "eea"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "dataStorageAndProcessingLocations",
-              "target_field": "dataStorageAndProcessingLocations",
-              "any_of": [
-                "uk",
-                "eea"
-              ],
-              "append_value": [
-                "privacy_shield"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "governmentSecurityClearances",
-              "target_field": "governmentSecurityClearances",
-              "any_of": [
-                "dv",
-                "sc"
-              ],
-              "append_value": [
-                "sc"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "governmentSecurityClearances",
-              "target_field": "governmentSecurityClearances",
-              "any_of": [
-                "dv",
-                "sc",
-                "bpss"
-              ],
-              "append_value": [
-                "bpss"
-              ]
-            }
-          }
-        ]
-      },
-      "dynamic": "strict",
-      "properties": {
-        "dmtext_id": {
-          "type": "keyword"
-        },
-        "sortonly_serviceIdHash": {
-          "type": "keyword"
-        },
-        "dmagg_lot": {
-          "type": "keyword"
-        },
-        "dmtext_lot": {
-          "type": "keyword"
-        },
-        "dmtext_lotName": {
-          "type": "text"
-        },
-        "dmtext_frameworkName": {
-          "type": "keyword"
-        },
-        "dmtext_serviceName": {
-          "type": "text"
-        },
-        "dmtext_serviceDescription": {
-          "term_vector": "with_positions_offsets",
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_serviceBenefits": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_serviceFeatures": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_supplierName": {
-          "type": "text"
-        },
-        "dmfilter_lot": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmagg_serviceCategories": {
-          "type": "keyword"
-        },
-        "dmtext_serviceCategories": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmfilter_serviceCategories": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_cloudDeploymentModel": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_resellingType": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_emailOrTicketingSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_phoneSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_webChatSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_onsiteSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_browsersAccess": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_installation": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_mobile": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_APISoftware": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_metricsHow": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_metricsWhat": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_scalingType": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_usageNotifications": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_backup": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_backupDatacentre": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_publicSectorNetworksTypes": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_dataProtectionBetweenNetworks": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_dataProtectionWithinNetwork": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_dataStorageAndProcessingLocations": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_userAuthentication": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_managementAccessAuthentication": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsISOIEC27001": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsISO28000": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsCSASTAR": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsPCI": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_securityGovernanceStandards": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_datacentreSecurityStandards": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_staffSecurityClearanceChecks": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_governmentSecurityClearances": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_educationPricing": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_freeVersionTrialOption": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
+    "_meta": {
+      "_": "DO NOT UPDATE BY HAND",
+      "version": "15.0.0",
+      "generated_from_framework": "g-cloud-10",
+      "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
+      "generated_time": "2019-03-06T09:18:21.596263",
+      "dm_sort_clause": [
+        "_score",
+        {
+          "sortonly_serviceIdHash": "desc"
         }
+      ],
+      "transformations": [
+        {
+          "hash_to": {
+            "field": "id",
+            "target_field": "serviceIdHash"
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Accounts payable",
+              "Accounts receivable",
+              "Asset management",
+              "Billing and invoicing",
+              "Budgeting",
+              "Contract management",
+              "Debt collection",
+              "Enterprise resource planning (ERP)",
+              "Expense management, expense reporting",
+              "Farming and farm management",
+              "Financial compliance",
+              "Financial management",
+              "Financial risk management",
+              "Land management",
+              "Payment gateway",
+              "Payroll",
+              "Portfolio analysis",
+              "Procurement",
+              "Purchasing",
+              "Revenue cycle management",
+              "Tax management",
+              "Other accounting and finance services"
+            ],
+            "append_value": [
+              "Accounting and finance"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Analytics",
+              "Business intelligence",
+              "Data mining, analysis tools and analytics",
+              "Data visualisation",
+              "Reporting and dashboards"
+            ],
+            "append_value": [
+              "Analytics and business intelligence"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Anti-spam and CAPTCHA",
+              "Audit tools",
+              "Authentication, identity and access management",
+              "Encryption",
+              "Log management",
+              "Remote access",
+              "Secure content and threat management",
+              "Security risk management"
+            ],
+            "append_value": [
+              "Application security"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Blogging",
+              "Booking, scheduling and diary management",
+              "Calendar",
+              "Case management",
+              "Content management system (CMS)",
+              "Content storage and sharing",
+              "Email and secure email",
+              "Enterprise social networking",
+              "File sending and file sharing",
+              "Idea management",
+              "Instant messaging (IM) and chat",
+              "Meeting management",
+              "Online forum or community",
+              "Online meetings",
+              "Presentations and slides (office productivity)",
+              "Project collaboration",
+              "Spreadsheets (office productivity)",
+              "Task management",
+              "Webinars",
+              "Word processing (office productivity)",
+              "Workflow"
+            ],
+            "append_value": [
+              "Collaborative working"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Accessibility checking",
+              "Blogging",
+              "Content management system (CMS)",
+              "Design",
+              "Diagram and wireframe",
+              "Digital publishing",
+              "Online forums",
+              "Photography and multimedia",
+              "Presentations and slides (office productivity)",
+              "Social networking",
+              "Word processing (office productivity)"
+            ],
+            "append_value": [
+              "Creative, design and publishing"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Call centre",
+              "Constituent engagement",
+              "Contact management",
+              "CRM system",
+              "Customer helpdesk (service desk)",
+              "Customer service and support",
+              "Feedback and reviews management",
+              "Forms and surveys",
+              "Live chat",
+              "Partner relationship management (PRM)",
+              "Virtual agents",
+              "Other CRM services"
+            ],
+            "append_value": [
+              "Customer relationship management (CRM)"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Backup, recovery and archival",
+              "Content management system (CMS)",
+              "Document management",
+              "Electronic data interchange (EDI)",
+              "Electronic signatures",
+              "File sending and sharing",
+              "File storage",
+              "Image management and picture archiving"
+            ],
+            "append_value": [
+              "Electronic document and records management (EDRM)"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Assisted living monitoring",
+              "Chiropractic",
+              "Clinical decision support",
+              "Clinical trial management",
+              "Dental",
+              "Electronic medical records",
+              "Healthcare analytics",
+              "Healthcare management",
+              "Home healthcare",
+              "Long-term care",
+              "Medical billing",
+              "Medical imaging",
+              "Medical lab",
+              "Medical practice",
+              "Medical scheduling and booking",
+              "Mental health",
+              "Optometry",
+              "Patient case management, care pathway management",
+              "Pharmacy",
+              "Pharmacy management",
+              "Physical therapy"
+            ],
+            "append_value": [
+              "Healthcare"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Applicant tracking",
+              "Benefits administration",
+              "Culture management",
+              "Employee scheduling",
+              "Employee self-service",
+              "Enterprise social networking",
+              "Examination (applicant testing)",
+              "Holiday planning and absence management",
+              "Payroll",
+              "Performance management",
+              "Recruitment",
+              "Salary",
+              "Talent (retention management)",
+              "Time and expense tracking",
+              "Training",
+              "Workforce analytics",
+              "Workforce management"
+            ],
+            "append_value": [
+              "Human resources and employee management"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "API connectors and interface engines",
+              "Application lifecycle management",
+              "Authentication, identity and access management",
+              "Backup, recovery and archival",
+              "Calendar",
+              "Call accounting",
+              "Call centre",
+              "Configuration and patch management",
+              "Desktop as a Service",
+              "Electronic data interchange (EDI)",
+              "Email and secure email",
+              "Fault management, monitoring and alerting",
+              "Fax",
+              "File sending and file sharing",
+              "File storage",
+              "Forms and surveys",
+              "Geographic information systems and mapping",
+              "Instant messaging (IM) and chat",
+              "Interactive voice response (IVR)",
+              "IT asset management",
+              "Licence management",
+              "Machine learning and artificial intelligence",
+              "Mobile device management",
+              "Natural language and speech processing",
+              "Network services (DNS)",
+              "Online meetings",
+              "Password management",
+              "Performance management",
+              "Post (mailing services)",
+              "Presentations and slides (office productivity)",
+              "Printing",
+              "Security",
+              "SMS",
+              "Spreadsheets (office productivity)",
+              "Systems monitoring",
+              "Telecoms expense management",
+              "Telephony (including VOIP and SIP connectivity)",
+              "Unified communications",
+              "Video conferencing",
+              "Virtual private network (VPN)",
+              "Word processing (office productivity)",
+              "Other information and communications technology (ICT) services"
+            ],
+            "append_value": [
+              "Information and communications technology (ICT)"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Electronic discovery (legal)",
+              "Law enforcement",
+              "Law practice management",
+              "Legal billing",
+              "Legal calendar",
+              "Legal case management",
+              "Legal document management",
+              "Trust accounting"
+            ],
+            "append_value": [
+              "Legal and enforcement"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Advertising",
+              "Affiliate marketing",
+              "Behavioural targeting",
+              "Brand management",
+              "Campaign management",
+              "Community management",
+              "Contextual marketing",
+              "Display advertising",
+              "Email marketing",
+              "Forms and surveys",
+              "Marketing analytics",
+              "Marketing automation",
+              "Marketing data",
+              "Mobile marketing",
+              "Online display advertising",
+              "Personalisation and behavioral targeting",
+              "Public relations",
+              "Search marketing",
+              "Social marketing",
+              "Social media marketing",
+              "Social media monitoring",
+              "Webinars",
+              "Other marketing services"
+            ],
+            "append_value": [
+              "Marketing"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Applications",
+              "Building information modelling (BIM)",
+              "Business management",
+              "Business performance management",
+              "Business process management (BPM)",
+              "Business process modelling (BPM)",
+              "Business transformation and organisational change management",
+              "Carbon, energy and sustainability management",
+              "Complex event processing",
+              "Contract management",
+              "Digital asset management",
+              "Digital signatures",
+              "Enterprise resource planning (ERP)",
+              "Facility management",
+              "Field service management",
+              "Governance, risk management and compliance (GRC)",
+              "Inventory management",
+              "Order management",
+              "Procurement",
+              "Product lifecycle management",
+              "Scheduling and appointments",
+              "Supply chain management",
+              "Visitor management",
+              "Workflow",
+              "Other operations management services"
+            ],
+            "append_value": [
+              "Operations management"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Agile project management and issue tracking",
+              "Professional services automation (PSA)",
+              "Project management",
+              "Project portfolio management (PPM)",
+              "Task management",
+              "Time and expense tracking"
+            ],
+            "append_value": [
+              "Project management and planning"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Configure, price and quote (CPQ)",
+              "eCommerce and shopping cart",
+              "Payment gateway",
+              "Recurring billing and subscription management",
+              "Sales and operations planning",
+              "Sales intelligence tracking",
+              "Sales performance management",
+              "Other sales services"
+            ],
+            "append_value": [
+              "Sales"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Academic",
+              "Alumni management",
+              "Asynchronous learning",
+              "Campus management",
+              "Classroom management",
+              "eLearning",
+              "Examination or applicant testing",
+              "Library automation",
+              "Library management",
+              "Online courses",
+              "Online grading",
+              "School accounting",
+              "School administration",
+              "Student management",
+              "Synchronous learning"
+            ],
+            "append_value": [
+              "Schools, education and libraries"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Accessibility",
+              "Agile project management and issue tracking",
+              "Bug tracking",
+              "Build tools",
+              "Code generation",
+              "Development tools",
+              "Form building",
+              "Integrated development environment (IDE)",
+              "Mobile development",
+              "Search",
+              "Source code management",
+              "Testing and optimisation",
+              "Usability",
+              "Version control",
+              "Website builder"
+            ],
+            "append_value": [
+              "Software development tools"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Airport management",
+              "Aviation maintenance",
+              "Distribution",
+              "Fleet management",
+              "Fleet tracking",
+              "Freight management",
+              "Inventory management",
+              "Marine",
+              "Shipping",
+              "Transportation dispatch",
+              "Trucking solutions",
+              "Warehouse management",
+              "Other transport and logistics services"
+            ],
+            "append_value": [
+              "Transport and logistics"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "setupAndMigrationService",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Planning"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "setupAndMigrationService",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Setup and migration"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "QAAndTesting",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Quality assurance and performance testing"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "securityTesting",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Security services"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "training",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Training"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "ongoingSupport",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Ongoing support"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "emailOrTicketingSupport",
+            "target_field": "emailOrTicketingSupport",
+            "any_of": [
+              "yes_extra_cost"
+            ],
+            "append_value": [
+              "yes"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "webChatSupport",
+            "target_field": "webChatSupport",
+            "any_of": [
+              "yes_extra_cost"
+            ],
+            "append_value": [
+              "yes"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "onsiteSupport",
+            "target_field": "onsiteSupport",
+            "any_of": [
+              "yes_extra_cost"
+            ],
+            "append_value": [
+              "yes"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "dataStorageAndProcessingLocations",
+            "target_field": "dataStorageAndProcessingLocations",
+            "any_of": [
+              "uk"
+            ],
+            "append_value": [
+              "eea"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "dataStorageAndProcessingLocations",
+            "target_field": "dataStorageAndProcessingLocations",
+            "any_of": [
+              "uk",
+              "eea"
+            ],
+            "append_value": [
+              "privacy_shield"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "governmentSecurityClearances",
+            "target_field": "governmentSecurityClearances",
+            "any_of": [
+              "dv",
+              "sc"
+            ],
+            "append_value": [
+              "sc"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "governmentSecurityClearances",
+            "target_field": "governmentSecurityClearances",
+            "any_of": [
+              "dv",
+              "sc",
+              "bpss"
+            ],
+            "append_value": [
+              "bpss"
+            ]
+          }
+        }
+      ]
+    },
+    "dynamic": "strict",
+    "properties": {
+      "dmtext_id": {
+        "type": "keyword"
+      },
+      "sortonly_serviceIdHash": {
+        "type": "keyword"
+      },
+      "dmagg_lot": {
+        "type": "keyword"
+      },
+      "dmtext_lot": {
+        "type": "keyword"
+      },
+      "dmtext_lotName": {
+        "type": "text"
+      },
+      "dmtext_frameworkName": {
+        "type": "keyword"
+      },
+      "dmtext_serviceName": {
+        "type": "text"
+      },
+      "dmtext_serviceDescription": {
+        "term_vector": "with_positions_offsets",
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_serviceBenefits": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_serviceFeatures": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_supplierName": {
+        "type": "text"
+      },
+      "dmfilter_lot": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmagg_serviceCategories": {
+        "type": "keyword"
+      },
+      "dmtext_serviceCategories": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmfilter_serviceCategories": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_cloudDeploymentModel": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_resellingType": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_emailOrTicketingSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_phoneSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_webChatSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_onsiteSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_browsersAccess": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_installation": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_mobile": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_APISoftware": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_metricsHow": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_metricsWhat": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_scalingType": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_usageNotifications": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_backup": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_backupDatacentre": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_publicSectorNetworksTypes": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_dataProtectionBetweenNetworks": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_dataProtectionWithinNetwork": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_dataStorageAndProcessingLocations": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_userAuthentication": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_managementAccessAuthentication": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsISOIEC27001": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsISO28000": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsCSASTAR": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsPCI": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_securityGovernanceStandards": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_datacentreSecurityStandards": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_staffSecurityClearanceChecks": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_governmentSecurityClearances": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_educationPricing": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_freeVersionTrialOption": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
       }
     }
   }

--- a/mappings/services-g-cloud-10.json
+++ b/mappings/services-g-cloud-10.json
@@ -51,6 +51,7 @@
       "generated_from_framework": "g-cloud-10",
       "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
       "generated_time": "2019-03-06T09:18:21.596263",
+      "doc_type": "services",
       "dm_sort_clause": [
         "_score",
         {

--- a/mappings/services-g-cloud-11.json
+++ b/mappings/services-g-cloud-11.json
@@ -8,7 +8,6 @@
         "stemming_analyzer": {
           "tokenizer": "standard",
           "filter": [
-            "standard",
             "lowercase",
             "possessive_english_stemmer",
             "light_english_stemmer"

--- a/mappings/services-g-cloud-11.json
+++ b/mappings/services-g-cloud-11.json
@@ -45,830 +45,828 @@
     }
   },
   "mappings": {
-    "services": {
-      "_meta": {
-        "_": "DO NOT UPDATE BY HAND",
-        "version": "16.1.2",
-        "generated_from_framework": "g-cloud-11",
-        "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2019-07-30T10:55:37.561144",
-        "dm_sort_clause": [
-          "_score",
-          {
-            "sortonly_serviceIdHash": "desc"
-          }
-        ],
-        "transformations": [
-          {
-            "hash_to": {
-              "field": "id",
-              "target_field": "serviceIdHash"
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Accounts payable",
-                "Accounts receivable",
-                "Asset management",
-                "Billing and invoicing",
-                "Budgeting",
-                "Contract management",
-                "Debt collection",
-                "Enterprise resource planning (ERP)",
-                "Expense management, expense reporting",
-                "Farming and farm management",
-                "Financial compliance",
-                "Financial management",
-                "Financial risk management",
-                "Land management",
-                "Payment gateway",
-                "Payroll",
-                "Portfolio analysis",
-                "Procurement",
-                "Purchasing",
-                "Revenue cycle management",
-                "Tax management",
-                "Other accounting and finance services"
-              ],
-              "append_value": [
-                "Accounting and finance"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Analytics",
-                "Business intelligence",
-                "Data mining, analysis tools and analytics",
-                "Data visualisation",
-                "Reporting and dashboards"
-              ],
-              "append_value": [
-                "Analytics and business intelligence"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Anti-spam and CAPTCHA",
-                "Audit tools",
-                "Authentication, identity and access management",
-                "Encryption",
-                "Log management",
-                "Remote access",
-                "Secure content and threat management",
-                "Security risk management"
-              ],
-              "append_value": [
-                "Application security"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Blogging",
-                "Booking, scheduling and diary management",
-                "Calendar",
-                "Case management",
-                "Content management system (CMS)",
-                "Content storage and sharing",
-                "Email and secure email",
-                "Enterprise social networking",
-                "File sending and file sharing",
-                "Idea management",
-                "Instant messaging (IM) and chat",
-                "Meeting management",
-                "Online forum or community",
-                "Online meetings",
-                "Presentations and slides (office productivity)",
-                "Project collaboration",
-                "Spreadsheets (office productivity)",
-                "Task management",
-                "Webinars",
-                "Word processing (office productivity)",
-                "Workflow"
-              ],
-              "append_value": [
-                "Collaborative working"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Accessibility checking",
-                "Blogging",
-                "Content management system (CMS)",
-                "Design",
-                "Diagram and wireframe",
-                "Digital publishing",
-                "Online forums",
-                "Photography and multimedia",
-                "Presentations and slides (office productivity)",
-                "Social networking",
-                "Word processing (office productivity)"
-              ],
-              "append_value": [
-                "Creative, design and publishing"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Call centre",
-                "Constituent engagement",
-                "Contact management",
-                "CRM system",
-                "Customer helpdesk (service desk)",
-                "Customer service and support",
-                "Feedback and reviews management",
-                "Forms and surveys",
-                "Live chat",
-                "Partner relationship management (PRM)",
-                "Virtual agents",
-                "Other CRM services"
-              ],
-              "append_value": [
-                "Customer relationship management (CRM)"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Backup, recovery and archival",
-                "Content management system (CMS)",
-                "Document management",
-                "Electronic data interchange (EDI)",
-                "Electronic signatures",
-                "File sending and sharing",
-                "File storage",
-                "Image management and picture archiving"
-              ],
-              "append_value": [
-                "Electronic document and records management (EDRM)"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Assisted living monitoring",
-                "Chiropractic",
-                "Clinical decision support",
-                "Clinical trial management",
-                "Dental",
-                "Electronic medical records",
-                "Healthcare analytics",
-                "Healthcare management",
-                "Home healthcare",
-                "Long-term care",
-                "Medical billing",
-                "Medical imaging",
-                "Medical lab",
-                "Medical practice",
-                "Medical scheduling and booking",
-                "Mental health",
-                "Optometry",
-                "Patient case management, care pathway management",
-                "Pharmacy",
-                "Pharmacy management",
-                "Physical therapy"
-              ],
-              "append_value": [
-                "Healthcare"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Applicant tracking",
-                "Benefits administration",
-                "Culture management",
-                "Employee scheduling",
-                "Employee self-service",
-                "Enterprise social networking",
-                "Examination (applicant testing)",
-                "Holiday planning and absence management",
-                "Payroll",
-                "Performance management",
-                "Recruitment",
-                "Salary",
-                "Talent (retention management)",
-                "Time and expense tracking",
-                "Training",
-                "Workforce analytics",
-                "Workforce management"
-              ],
-              "append_value": [
-                "Human resources and employee management"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "API connectors and interface engines",
-                "Application lifecycle management",
-                "Authentication, identity and access management",
-                "Backup, recovery and archival",
-                "Calendar",
-                "Call accounting",
-                "Call centre",
-                "Configuration and patch management",
-                "Desktop as a Service",
-                "Electronic data interchange (EDI)",
-                "Email and secure email",
-                "Fault management, monitoring and alerting",
-                "Fax",
-                "File sending and file sharing",
-                "File storage",
-                "Forms and surveys",
-                "Geographic information systems and mapping",
-                "Instant messaging (IM) and chat",
-                "Interactive voice response (IVR)",
-                "IT asset management",
-                "Licence management",
-                "Machine learning and artificial intelligence",
-                "Mobile device management",
-                "Natural language and speech processing",
-                "Network services (DNS)",
-                "Online meetings",
-                "Password management",
-                "Performance management",
-                "Post (mailing services)",
-                "Presentations and slides (office productivity)",
-                "Printing",
-                "Security",
-                "SMS",
-                "Spreadsheets (office productivity)",
-                "Systems monitoring",
-                "Telecoms expense management",
-                "Telephony (including VOIP and SIP connectivity)",
-                "Unified communications",
-                "Video conferencing",
-                "Virtual private network (VPN)",
-                "Word processing (office productivity)",
-                "Other information and communications technology (ICT) services"
-              ],
-              "append_value": [
-                "Information and communications technology (ICT)"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Electronic discovery (legal)",
-                "Law enforcement",
-                "Law practice management",
-                "Legal billing",
-                "Legal calendar",
-                "Legal case management",
-                "Legal document management",
-                "Trust accounting"
-              ],
-              "append_value": [
-                "Legal and enforcement"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Advertising",
-                "Affiliate marketing",
-                "Behavioural targeting",
-                "Brand management",
-                "Campaign management",
-                "Community management",
-                "Contextual marketing",
-                "Display advertising",
-                "Email marketing",
-                "Forms and surveys",
-                "Marketing analytics",
-                "Marketing automation",
-                "Marketing data",
-                "Mobile marketing",
-                "Online display advertising",
-                "Personalisation and behavioral targeting",
-                "Public relations",
-                "Search marketing",
-                "Social marketing",
-                "Social media marketing",
-                "Social media monitoring",
-                "Webinars",
-                "Other marketing services"
-              ],
-              "append_value": [
-                "Marketing"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Applications",
-                "Building information modelling (BIM)",
-                "Business management",
-                "Business performance management",
-                "Business process management (BPM)",
-                "Business process modelling (BPM)",
-                "Business transformation and organisational change management",
-                "Carbon, energy and sustainability management",
-                "Complex event processing",
-                "Contract management",
-                "Digital asset management",
-                "Digital signatures",
-                "Enterprise resource planning (ERP)",
-                "Facility management",
-                "Field service management",
-                "Governance, risk management and compliance (GRC)",
-                "Inventory management",
-                "Order management",
-                "Procurement",
-                "Product lifecycle management",
-                "Scheduling and appointments",
-                "Supply chain management",
-                "Visitor management",
-                "Workflow",
-                "Other operations management services"
-              ],
-              "append_value": [
-                "Operations management"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Agile project management and issue tracking",
-                "Professional services automation (PSA)",
-                "Project management",
-                "Project portfolio management (PPM)",
-                "Task management",
-                "Time and expense tracking"
-              ],
-              "append_value": [
-                "Project management and planning"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Configure, price and quote (CPQ)",
-                "eCommerce and shopping cart",
-                "Payment gateway",
-                "Recurring billing and subscription management",
-                "Sales and operations planning",
-                "Sales intelligence tracking",
-                "Sales performance management",
-                "Other sales services"
-              ],
-              "append_value": [
-                "Sales"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Academic",
-                "Alumni management",
-                "Asynchronous learning",
-                "Campus management",
-                "Classroom management",
-                "eLearning",
-                "Examination or applicant testing",
-                "Library automation",
-                "Library management",
-                "Online courses",
-                "Online grading",
-                "School accounting",
-                "School administration",
-                "Student management",
-                "Synchronous learning"
-              ],
-              "append_value": [
-                "Schools, education and libraries"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Accessibility",
-                "Agile project management and issue tracking",
-                "Bug tracking",
-                "Build tools",
-                "Code generation",
-                "Development tools",
-                "Form building",
-                "Integrated development environment (IDE)",
-                "Mobile development",
-                "Search",
-                "Source code management",
-                "Testing and optimisation",
-                "Usability",
-                "Version control",
-                "Website builder"
-              ],
-              "append_value": [
-                "Software development tools"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Airport management",
-                "Aviation maintenance",
-                "Distribution",
-                "Fleet management",
-                "Fleet tracking",
-                "Freight management",
-                "Inventory management",
-                "Marine",
-                "Shipping",
-                "Transportation dispatch",
-                "Trucking solutions",
-                "Warehouse management",
-                "Other transport and logistics services"
-              ],
-              "append_value": [
-                "Transport and logistics"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "planningService",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Planning"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "setupAndMigrationService",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Setup and migration"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "QAAndTesting",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Quality assurance and performance testing"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "securityTesting",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Security services"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "training",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Training"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "ongoingSupport",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Ongoing support"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "emailOrTicketingSupport",
-              "target_field": "emailOrTicketingSupport",
-              "any_of": [
-                "yes_extra_cost"
-              ],
-              "append_value": [
-                "yes"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "webChatSupport",
-              "target_field": "webChatSupport",
-              "any_of": [
-                "yes_extra_cost"
-              ],
-              "append_value": [
-                "yes"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "onsiteSupport",
-              "target_field": "onsiteSupport",
-              "any_of": [
-                "yes_extra_cost"
-              ],
-              "append_value": [
-                "yes"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "dataStorageAndProcessingLocations",
-              "target_field": "dataStorageAndProcessingLocations",
-              "any_of": [
-                "uk"
-              ],
-              "append_value": [
-                "eea"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "dataStorageAndProcessingLocations",
-              "target_field": "dataStorageAndProcessingLocations",
-              "any_of": [
-                "uk",
-                "eea"
-              ],
-              "append_value": [
-                "privacy_shield"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "governmentSecurityClearances",
-              "target_field": "governmentSecurityClearances",
-              "any_of": [
-                "dv",
-                "sc"
-              ],
-              "append_value": [
-                "sc"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "governmentSecurityClearances",
-              "target_field": "governmentSecurityClearances",
-              "any_of": [
-                "dv",
-                "sc",
-                "bpss"
-              ],
-              "append_value": [
-                "bpss"
-              ]
-            }
-          }
-        ]
-      },
-      "dynamic": "strict",
-      "properties": {
-        "dmtext_id": {
-          "type": "keyword"
-        },
-        "sortonly_serviceIdHash": {
-          "type": "keyword"
-        },
-        "dmagg_lot": {
-          "type": "keyword"
-        },
-        "dmtext_lot": {
-          "type": "keyword"
-        },
-        "dmtext_lotName": {
-          "type": "text"
-        },
-        "dmtext_frameworkName": {
-          "type": "keyword"
-        },
-        "dmtext_serviceName": {
-          "type": "text"
-        },
-        "dmtext_serviceDescription": {
-          "term_vector": "with_positions_offsets",
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_serviceBenefits": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_serviceFeatures": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_supplierName": {
-          "type": "text"
-        },
-        "dmfilter_lot": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmagg_serviceCategories": {
-          "type": "keyword"
-        },
-        "dmtext_serviceCategories": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmfilter_serviceCategories": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_cloudDeploymentModel": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_resellingType": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_emailOrTicketingSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_phoneSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_webChatSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_onsiteSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_browsersAccess": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_installation": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_mobile": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_APISoftware": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_metricsHow": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_metricsWhat": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_scalingType": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_usageNotifications": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_backup": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_backupDatacentre": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_publicSectorNetworksTypes": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_dataProtectionBetweenNetworks": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_dataProtectionWithinNetwork": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_dataStorageAndProcessingLocations": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_userAuthentication": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_managementAccessAuthentication": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsISOIEC27001": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsISO28000": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsCSASTAR": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsPCI": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_securityGovernanceStandards": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_datacentreSecurityStandards": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_staffSecurityClearanceChecks": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_governmentSecurityClearances": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_educationPricing": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_freeVersionTrialOption": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
+    "_meta": {
+      "_": "DO NOT UPDATE BY HAND",
+      "version": "16.1.2",
+      "generated_from_framework": "g-cloud-11",
+      "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
+      "generated_time": "2019-07-30T10:55:37.561144",
+      "dm_sort_clause": [
+        "_score",
+        {
+          "sortonly_serviceIdHash": "desc"
         }
+      ],
+      "transformations": [
+        {
+          "hash_to": {
+            "field": "id",
+            "target_field": "serviceIdHash"
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Accounts payable",
+              "Accounts receivable",
+              "Asset management",
+              "Billing and invoicing",
+              "Budgeting",
+              "Contract management",
+              "Debt collection",
+              "Enterprise resource planning (ERP)",
+              "Expense management, expense reporting",
+              "Farming and farm management",
+              "Financial compliance",
+              "Financial management",
+              "Financial risk management",
+              "Land management",
+              "Payment gateway",
+              "Payroll",
+              "Portfolio analysis",
+              "Procurement",
+              "Purchasing",
+              "Revenue cycle management",
+              "Tax management",
+              "Other accounting and finance services"
+            ],
+            "append_value": [
+              "Accounting and finance"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Analytics",
+              "Business intelligence",
+              "Data mining, analysis tools and analytics",
+              "Data visualisation",
+              "Reporting and dashboards"
+            ],
+            "append_value": [
+              "Analytics and business intelligence"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Anti-spam and CAPTCHA",
+              "Audit tools",
+              "Authentication, identity and access management",
+              "Encryption",
+              "Log management",
+              "Remote access",
+              "Secure content and threat management",
+              "Security risk management"
+            ],
+            "append_value": [
+              "Application security"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Blogging",
+              "Booking, scheduling and diary management",
+              "Calendar",
+              "Case management",
+              "Content management system (CMS)",
+              "Content storage and sharing",
+              "Email and secure email",
+              "Enterprise social networking",
+              "File sending and file sharing",
+              "Idea management",
+              "Instant messaging (IM) and chat",
+              "Meeting management",
+              "Online forum or community",
+              "Online meetings",
+              "Presentations and slides (office productivity)",
+              "Project collaboration",
+              "Spreadsheets (office productivity)",
+              "Task management",
+              "Webinars",
+              "Word processing (office productivity)",
+              "Workflow"
+            ],
+            "append_value": [
+              "Collaborative working"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Accessibility checking",
+              "Blogging",
+              "Content management system (CMS)",
+              "Design",
+              "Diagram and wireframe",
+              "Digital publishing",
+              "Online forums",
+              "Photography and multimedia",
+              "Presentations and slides (office productivity)",
+              "Social networking",
+              "Word processing (office productivity)"
+            ],
+            "append_value": [
+              "Creative, design and publishing"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Call centre",
+              "Constituent engagement",
+              "Contact management",
+              "CRM system",
+              "Customer helpdesk (service desk)",
+              "Customer service and support",
+              "Feedback and reviews management",
+              "Forms and surveys",
+              "Live chat",
+              "Partner relationship management (PRM)",
+              "Virtual agents",
+              "Other CRM services"
+            ],
+            "append_value": [
+              "Customer relationship management (CRM)"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Backup, recovery and archival",
+              "Content management system (CMS)",
+              "Document management",
+              "Electronic data interchange (EDI)",
+              "Electronic signatures",
+              "File sending and sharing",
+              "File storage",
+              "Image management and picture archiving"
+            ],
+            "append_value": [
+              "Electronic document and records management (EDRM)"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Assisted living monitoring",
+              "Chiropractic",
+              "Clinical decision support",
+              "Clinical trial management",
+              "Dental",
+              "Electronic medical records",
+              "Healthcare analytics",
+              "Healthcare management",
+              "Home healthcare",
+              "Long-term care",
+              "Medical billing",
+              "Medical imaging",
+              "Medical lab",
+              "Medical practice",
+              "Medical scheduling and booking",
+              "Mental health",
+              "Optometry",
+              "Patient case management, care pathway management",
+              "Pharmacy",
+              "Pharmacy management",
+              "Physical therapy"
+            ],
+            "append_value": [
+              "Healthcare"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Applicant tracking",
+              "Benefits administration",
+              "Culture management",
+              "Employee scheduling",
+              "Employee self-service",
+              "Enterprise social networking",
+              "Examination (applicant testing)",
+              "Holiday planning and absence management",
+              "Payroll",
+              "Performance management",
+              "Recruitment",
+              "Salary",
+              "Talent (retention management)",
+              "Time and expense tracking",
+              "Training",
+              "Workforce analytics",
+              "Workforce management"
+            ],
+            "append_value": [
+              "Human resources and employee management"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "API connectors and interface engines",
+              "Application lifecycle management",
+              "Authentication, identity and access management",
+              "Backup, recovery and archival",
+              "Calendar",
+              "Call accounting",
+              "Call centre",
+              "Configuration and patch management",
+              "Desktop as a Service",
+              "Electronic data interchange (EDI)",
+              "Email and secure email",
+              "Fault management, monitoring and alerting",
+              "Fax",
+              "File sending and file sharing",
+              "File storage",
+              "Forms and surveys",
+              "Geographic information systems and mapping",
+              "Instant messaging (IM) and chat",
+              "Interactive voice response (IVR)",
+              "IT asset management",
+              "Licence management",
+              "Machine learning and artificial intelligence",
+              "Mobile device management",
+              "Natural language and speech processing",
+              "Network services (DNS)",
+              "Online meetings",
+              "Password management",
+              "Performance management",
+              "Post (mailing services)",
+              "Presentations and slides (office productivity)",
+              "Printing",
+              "Security",
+              "SMS",
+              "Spreadsheets (office productivity)",
+              "Systems monitoring",
+              "Telecoms expense management",
+              "Telephony (including VOIP and SIP connectivity)",
+              "Unified communications",
+              "Video conferencing",
+              "Virtual private network (VPN)",
+              "Word processing (office productivity)",
+              "Other information and communications technology (ICT) services"
+            ],
+            "append_value": [
+              "Information and communications technology (ICT)"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Electronic discovery (legal)",
+              "Law enforcement",
+              "Law practice management",
+              "Legal billing",
+              "Legal calendar",
+              "Legal case management",
+              "Legal document management",
+              "Trust accounting"
+            ],
+            "append_value": [
+              "Legal and enforcement"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Advertising",
+              "Affiliate marketing",
+              "Behavioural targeting",
+              "Brand management",
+              "Campaign management",
+              "Community management",
+              "Contextual marketing",
+              "Display advertising",
+              "Email marketing",
+              "Forms and surveys",
+              "Marketing analytics",
+              "Marketing automation",
+              "Marketing data",
+              "Mobile marketing",
+              "Online display advertising",
+              "Personalisation and behavioral targeting",
+              "Public relations",
+              "Search marketing",
+              "Social marketing",
+              "Social media marketing",
+              "Social media monitoring",
+              "Webinars",
+              "Other marketing services"
+            ],
+            "append_value": [
+              "Marketing"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Applications",
+              "Building information modelling (BIM)",
+              "Business management",
+              "Business performance management",
+              "Business process management (BPM)",
+              "Business process modelling (BPM)",
+              "Business transformation and organisational change management",
+              "Carbon, energy and sustainability management",
+              "Complex event processing",
+              "Contract management",
+              "Digital asset management",
+              "Digital signatures",
+              "Enterprise resource planning (ERP)",
+              "Facility management",
+              "Field service management",
+              "Governance, risk management and compliance (GRC)",
+              "Inventory management",
+              "Order management",
+              "Procurement",
+              "Product lifecycle management",
+              "Scheduling and appointments",
+              "Supply chain management",
+              "Visitor management",
+              "Workflow",
+              "Other operations management services"
+            ],
+            "append_value": [
+              "Operations management"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Agile project management and issue tracking",
+              "Professional services automation (PSA)",
+              "Project management",
+              "Project portfolio management (PPM)",
+              "Task management",
+              "Time and expense tracking"
+            ],
+            "append_value": [
+              "Project management and planning"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Configure, price and quote (CPQ)",
+              "eCommerce and shopping cart",
+              "Payment gateway",
+              "Recurring billing and subscription management",
+              "Sales and operations planning",
+              "Sales intelligence tracking",
+              "Sales performance management",
+              "Other sales services"
+            ],
+            "append_value": [
+              "Sales"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Academic",
+              "Alumni management",
+              "Asynchronous learning",
+              "Campus management",
+              "Classroom management",
+              "eLearning",
+              "Examination or applicant testing",
+              "Library automation",
+              "Library management",
+              "Online courses",
+              "Online grading",
+              "School accounting",
+              "School administration",
+              "Student management",
+              "Synchronous learning"
+            ],
+            "append_value": [
+              "Schools, education and libraries"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Accessibility",
+              "Agile project management and issue tracking",
+              "Bug tracking",
+              "Build tools",
+              "Code generation",
+              "Development tools",
+              "Form building",
+              "Integrated development environment (IDE)",
+              "Mobile development",
+              "Search",
+              "Source code management",
+              "Testing and optimisation",
+              "Usability",
+              "Version control",
+              "Website builder"
+            ],
+            "append_value": [
+              "Software development tools"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Airport management",
+              "Aviation maintenance",
+              "Distribution",
+              "Fleet management",
+              "Fleet tracking",
+              "Freight management",
+              "Inventory management",
+              "Marine",
+              "Shipping",
+              "Transportation dispatch",
+              "Trucking solutions",
+              "Warehouse management",
+              "Other transport and logistics services"
+            ],
+            "append_value": [
+              "Transport and logistics"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "planningService",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Planning"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "setupAndMigrationService",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Setup and migration"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "QAAndTesting",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Quality assurance and performance testing"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "securityTesting",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Security services"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "training",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Training"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "ongoingSupport",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Ongoing support"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "emailOrTicketingSupport",
+            "target_field": "emailOrTicketingSupport",
+            "any_of": [
+              "yes_extra_cost"
+            ],
+            "append_value": [
+              "yes"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "webChatSupport",
+            "target_field": "webChatSupport",
+            "any_of": [
+              "yes_extra_cost"
+            ],
+            "append_value": [
+              "yes"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "onsiteSupport",
+            "target_field": "onsiteSupport",
+            "any_of": [
+              "yes_extra_cost"
+            ],
+            "append_value": [
+              "yes"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "dataStorageAndProcessingLocations",
+            "target_field": "dataStorageAndProcessingLocations",
+            "any_of": [
+              "uk"
+            ],
+            "append_value": [
+              "eea"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "dataStorageAndProcessingLocations",
+            "target_field": "dataStorageAndProcessingLocations",
+            "any_of": [
+              "uk",
+              "eea"
+            ],
+            "append_value": [
+              "privacy_shield"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "governmentSecurityClearances",
+            "target_field": "governmentSecurityClearances",
+            "any_of": [
+              "dv",
+              "sc"
+            ],
+            "append_value": [
+              "sc"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "governmentSecurityClearances",
+            "target_field": "governmentSecurityClearances",
+            "any_of": [
+              "dv",
+              "sc",
+              "bpss"
+            ],
+            "append_value": [
+              "bpss"
+            ]
+          }
+        }
+      ]
+    },
+    "dynamic": "strict",
+    "properties": {
+      "dmtext_id": {
+        "type": "keyword"
+      },
+      "sortonly_serviceIdHash": {
+        "type": "keyword"
+      },
+      "dmagg_lot": {
+        "type": "keyword"
+      },
+      "dmtext_lot": {
+        "type": "keyword"
+      },
+      "dmtext_lotName": {
+        "type": "text"
+      },
+      "dmtext_frameworkName": {
+        "type": "keyword"
+      },
+      "dmtext_serviceName": {
+        "type": "text"
+      },
+      "dmtext_serviceDescription": {
+        "term_vector": "with_positions_offsets",
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_serviceBenefits": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_serviceFeatures": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_supplierName": {
+        "type": "text"
+      },
+      "dmfilter_lot": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmagg_serviceCategories": {
+        "type": "keyword"
+      },
+      "dmtext_serviceCategories": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmfilter_serviceCategories": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_cloudDeploymentModel": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_resellingType": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_emailOrTicketingSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_phoneSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_webChatSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_onsiteSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_browsersAccess": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_installation": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_mobile": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_APISoftware": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_metricsHow": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_metricsWhat": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_scalingType": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_usageNotifications": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_backup": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_backupDatacentre": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_publicSectorNetworksTypes": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_dataProtectionBetweenNetworks": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_dataProtectionWithinNetwork": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_dataStorageAndProcessingLocations": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_userAuthentication": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_managementAccessAuthentication": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsISOIEC27001": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsISO28000": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsCSASTAR": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsPCI": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_securityGovernanceStandards": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_datacentreSecurityStandards": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_staffSecurityClearanceChecks": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_governmentSecurityClearances": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_educationPricing": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_freeVersionTrialOption": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
       }
     }
   }

--- a/mappings/services-g-cloud-11.json
+++ b/mappings/services-g-cloud-11.json
@@ -49,6 +49,7 @@
       "_": "DO NOT UPDATE BY HAND",
       "version": "16.1.2",
       "generated_from_framework": "g-cloud-11",
+      "doc_type": "services",
       "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
       "generated_time": "2019-07-30T10:55:37.561144",
       "dm_sort_clause": [

--- a/mappings/services-g-cloud-12.json
+++ b/mappings/services-g-cloud-12.json
@@ -8,7 +8,6 @@
         "stemming_analyzer": {
           "tokenizer": "standard",
           "filter": [
-            "standard",
             "lowercase",
             "possessive_english_stemmer",
             "light_english_stemmer"

--- a/mappings/services-g-cloud-12.json
+++ b/mappings/services-g-cloud-12.json
@@ -45,830 +45,828 @@
     }
   },
   "mappings": {
-    "services": {
-      "_meta": {
-        "_": "DO NOT UPDATE BY HAND",
-        "version": "17.13.1",
-        "generated_from_framework": "g-cloud-12",
-        "generated_by": "/home/benjamin/code/digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2020-09-25T12:26:15.712295",
-        "dm_sort_clause": [
-          "_score",
-          {
-            "sortonly_serviceIdHash": "desc"
-          }
-        ],
-        "transformations": [
-          {
-            "hash_to": {
-              "field": "id",
-              "target_field": "serviceIdHash"
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Accounts payable",
-                "Accounts receivable",
-                "Asset management",
-                "Billing and invoicing",
-                "Budgeting",
-                "Contract management",
-                "Debt collection",
-                "Enterprise resource planning (ERP)",
-                "Expense management, expense reporting",
-                "Farming and farm management",
-                "Financial compliance",
-                "Financial management",
-                "Financial risk management",
-                "Land management",
-                "Payment gateway",
-                "Payroll",
-                "Portfolio analysis",
-                "Procurement",
-                "Purchasing",
-                "Revenue cycle management",
-                "Tax management",
-                "Other accounting and finance services"
-              ],
-              "append_value": [
-                "Accounting and finance"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Analytics",
-                "Business intelligence",
-                "Data mining, analysis tools and analytics",
-                "Data visualisation",
-                "Reporting and dashboards"
-              ],
-              "append_value": [
-                "Analytics and business intelligence"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Anti-spam and CAPTCHA",
-                "Audit tools",
-                "Authentication, identity and access management",
-                "Encryption",
-                "Log management",
-                "Remote access",
-                "Secure content and threat management",
-                "Security risk management"
-              ],
-              "append_value": [
-                "Application security"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Blogging",
-                "Booking, scheduling and diary management",
-                "Calendar",
-                "Case management",
-                "Content management system (CMS)",
-                "Content storage and sharing",
-                "Email and secure email",
-                "Enterprise social networking",
-                "File sending and file sharing",
-                "Idea management",
-                "Instant messaging (IM) and chat",
-                "Meeting management",
-                "Online forum or community",
-                "Online meetings",
-                "Presentations and slides (office productivity)",
-                "Project collaboration",
-                "Spreadsheets (office productivity)",
-                "Task management",
-                "Webinars",
-                "Word processing (office productivity)",
-                "Workflow"
-              ],
-              "append_value": [
-                "Collaborative working"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Accessibility checking",
-                "Blogging",
-                "Content management system (CMS)",
-                "Design",
-                "Diagram and wireframe",
-                "Digital publishing",
-                "Online forums",
-                "Photography and multimedia",
-                "Presentations and slides (office productivity)",
-                "Social networking",
-                "Word processing (office productivity)"
-              ],
-              "append_value": [
-                "Creative, design and publishing"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Call centre",
-                "Constituent engagement",
-                "Contact management",
-                "CRM system",
-                "Customer helpdesk (service desk)",
-                "Customer service and support",
-                "Feedback and reviews management",
-                "Forms and surveys",
-                "Live chat",
-                "Partner relationship management (PRM)",
-                "Virtual agents",
-                "Other CRM services"
-              ],
-              "append_value": [
-                "Customer relationship management (CRM)"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Backup, recovery and archival",
-                "Content management system (CMS)",
-                "Document management",
-                "Electronic data interchange (EDI)",
-                "Electronic signatures",
-                "File sending and sharing",
-                "File storage",
-                "Image management and picture archiving"
-              ],
-              "append_value": [
-                "Electronic document and records management (EDRM)"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Assisted living monitoring",
-                "Chiropractic",
-                "Clinical decision support",
-                "Clinical trial management",
-                "Dental",
-                "Electronic medical records",
-                "Healthcare analytics",
-                "Healthcare management",
-                "Home healthcare",
-                "Long-term care",
-                "Medical billing",
-                "Medical imaging",
-                "Medical lab",
-                "Medical practice",
-                "Medical scheduling and booking",
-                "Mental health",
-                "Optometry",
-                "Patient case management, care pathway management",
-                "Pharmacy",
-                "Pharmacy management",
-                "Physical therapy"
-              ],
-              "append_value": [
-                "Healthcare"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Applicant tracking",
-                "Benefits administration",
-                "Culture management",
-                "Employee scheduling",
-                "Employee self-service",
-                "Enterprise social networking",
-                "Examination (applicant testing)",
-                "Holiday planning and absence management",
-                "Payroll",
-                "Performance management",
-                "Recruitment",
-                "Salary",
-                "Talent (retention management)",
-                "Time and expense tracking",
-                "Training",
-                "Workforce analytics",
-                "Workforce management"
-              ],
-              "append_value": [
-                "Human resources and employee management"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "API connectors and interface engines",
-                "Application lifecycle management",
-                "Authentication, identity and access management",
-                "Backup, recovery and archival",
-                "Calendar",
-                "Call accounting",
-                "Call centre",
-                "Configuration and patch management",
-                "Desktop as a Service",
-                "Electronic data interchange (EDI)",
-                "Email and secure email",
-                "Fault management, monitoring and alerting",
-                "Fax",
-                "File sending and file sharing",
-                "File storage",
-                "Forms and surveys",
-                "Geographic information systems and mapping",
-                "Instant messaging (IM) and chat",
-                "Interactive voice response (IVR)",
-                "IT asset management",
-                "Licence management",
-                "Machine learning and artificial intelligence",
-                "Mobile device management",
-                "Natural language and speech processing",
-                "Network services (DNS)",
-                "Online meetings",
-                "Password management",
-                "Performance management",
-                "Post (mailing services)",
-                "Presentations and slides (office productivity)",
-                "Printing",
-                "Security",
-                "SMS",
-                "Spreadsheets (office productivity)",
-                "Systems monitoring",
-                "Telecoms expense management",
-                "Telephony (including VOIP and SIP connectivity)",
-                "Unified communications",
-                "Video conferencing",
-                "Virtual private network (VPN)",
-                "Word processing (office productivity)",
-                "Other information and communications technology (ICT) services"
-              ],
-              "append_value": [
-                "Information and communications technology (ICT)"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Electronic discovery (legal)",
-                "Law enforcement",
-                "Law practice management",
-                "Legal billing",
-                "Legal calendar",
-                "Legal case management",
-                "Legal document management",
-                "Trust accounting"
-              ],
-              "append_value": [
-                "Legal and enforcement"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Advertising",
-                "Affiliate marketing",
-                "Behavioural targeting",
-                "Brand management",
-                "Campaign management",
-                "Community management",
-                "Contextual marketing",
-                "Display advertising",
-                "Email marketing",
-                "Forms and surveys",
-                "Marketing analytics",
-                "Marketing automation",
-                "Marketing data",
-                "Mobile marketing",
-                "Online display advertising",
-                "Personalisation and behavioral targeting",
-                "Public relations",
-                "Search marketing",
-                "Social marketing",
-                "Social media marketing",
-                "Social media monitoring",
-                "Webinars",
-                "Other marketing services"
-              ],
-              "append_value": [
-                "Marketing"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Applications",
-                "Building information modelling (BIM)",
-                "Business management",
-                "Business performance management",
-                "Business process management (BPM)",
-                "Business process modelling (BPM)",
-                "Business transformation and organisational change management",
-                "Carbon, energy and sustainability management",
-                "Complex event processing",
-                "Contract management",
-                "Digital asset management",
-                "Digital signatures",
-                "Enterprise resource planning (ERP)",
-                "Facility management",
-                "Field service management",
-                "Governance, risk management and compliance (GRC)",
-                "Inventory management",
-                "Order management",
-                "Procurement",
-                "Product lifecycle management",
-                "Scheduling and appointments",
-                "Supply chain management",
-                "Visitor management",
-                "Workflow",
-                "Other operations management services"
-              ],
-              "append_value": [
-                "Operations management"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Agile project management and issue tracking",
-                "Professional services automation (PSA)",
-                "Project management",
-                "Project portfolio management (PPM)",
-                "Task management",
-                "Time and expense tracking"
-              ],
-              "append_value": [
-                "Project management and planning"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Configure, price and quote (CPQ)",
-                "eCommerce and shopping cart",
-                "Payment gateway",
-                "Recurring billing and subscription management",
-                "Sales and operations planning",
-                "Sales intelligence tracking",
-                "Sales performance management",
-                "Other sales services"
-              ],
-              "append_value": [
-                "Sales"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Academic",
-                "Alumni management",
-                "Asynchronous learning",
-                "Campus management",
-                "Classroom management",
-                "eLearning",
-                "Examination or applicant testing",
-                "Library automation",
-                "Library management",
-                "Online courses",
-                "Online grading",
-                "School accounting",
-                "School administration",
-                "Student management",
-                "Synchronous learning"
-              ],
-              "append_value": [
-                "Schools, education and libraries"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Accessibility",
-                "Agile project management and issue tracking",
-                "Bug tracking",
-                "Build tools",
-                "Code generation",
-                "Development tools",
-                "Form building",
-                "Integrated development environment (IDE)",
-                "Mobile development",
-                "Search",
-                "Source code management",
-                "Testing and optimisation",
-                "Usability",
-                "Version control",
-                "Website builder"
-              ],
-              "append_value": [
-                "Software development tools"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Airport management",
-                "Aviation maintenance",
-                "Distribution",
-                "Fleet management",
-                "Fleet tracking",
-                "Freight management",
-                "Inventory management",
-                "Marine",
-                "Shipping",
-                "Transportation dispatch",
-                "Trucking solutions",
-                "Warehouse management",
-                "Other transport and logistics services"
-              ],
-              "append_value": [
-                "Transport and logistics"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "planningService",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Planning"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "setupAndMigrationService",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Setup and migration"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "QAAndTesting",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Quality assurance and performance testing"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "securityTesting",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Security services"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "training",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Training"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "ongoingSupport",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Ongoing support"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "emailOrTicketingSupport",
-              "target_field": "emailOrTicketingSupport",
-              "any_of": [
-                "yes_extra_cost"
-              ],
-              "append_value": [
-                "yes"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "webChatSupport",
-              "target_field": "webChatSupport",
-              "any_of": [
-                "yes_extra_cost"
-              ],
-              "append_value": [
-                "yes"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "onsiteSupport",
-              "target_field": "onsiteSupport",
-              "any_of": [
-                "yes_extra_cost"
-              ],
-              "append_value": [
-                "yes"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "dataStorageAndProcessingLocations",
-              "target_field": "dataStorageAndProcessingLocations",
-              "any_of": [
-                "uk"
-              ],
-              "append_value": [
-                "eea"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "dataStorageAndProcessingLocations",
-              "target_field": "dataStorageAndProcessingLocations",
-              "any_of": [
-                "uk",
-                "eea"
-              ],
-              "append_value": [
-                "privacy_shield"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "governmentSecurityClearances",
-              "target_field": "governmentSecurityClearances",
-              "any_of": [
-                "dv",
-                "sc"
-              ],
-              "append_value": [
-                "sc"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "governmentSecurityClearances",
-              "target_field": "governmentSecurityClearances",
-              "any_of": [
-                "dv",
-                "sc",
-                "bpss"
-              ],
-              "append_value": [
-                "bpss"
-              ]
-            }
-          }
-        ]
-      },
-      "dynamic": "strict",
-      "properties": {
-        "dmtext_id": {
-          "type": "keyword"
-        },
-        "sortonly_serviceIdHash": {
-          "type": "keyword"
-        },
-        "dmagg_lot": {
-          "type": "keyword"
-        },
-        "dmtext_lot": {
-          "type": "keyword"
-        },
-        "dmtext_lotName": {
-          "type": "text"
-        },
-        "dmtext_frameworkName": {
-          "type": "keyword"
-        },
-        "dmtext_serviceName": {
-          "type": "text"
-        },
-        "dmtext_serviceDescription": {
-          "term_vector": "with_positions_offsets",
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_serviceBenefits": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_serviceFeatures": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_supplierName": {
-          "type": "text"
-        },
-        "dmfilter_lot": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmagg_serviceCategories": {
-          "type": "keyword"
-        },
-        "dmtext_serviceCategories": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmfilter_serviceCategories": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_cloudDeploymentModel": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_resellingType": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_emailOrTicketingSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_phoneSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_webChatSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_onsiteSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_browsersAccess": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_installation": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_mobile": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_APISoftware": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_metricsHow": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_metricsWhat": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_scalingType": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_usageNotifications": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_backup": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_backupDatacentre": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_publicSectorNetworksTypes": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_dataProtectionBetweenNetworks": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_dataProtectionWithinNetwork": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_dataStorageAndProcessingLocations": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_userAuthentication": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_managementAccessAuthentication": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsISOIEC27001": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsISO28000": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsCSASTAR": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsPCI": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_securityGovernanceStandards": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_datacentreSecurityStandards": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_staffSecurityClearanceChecks": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_governmentSecurityClearances": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_educationPricing": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_freeVersionTrialOption": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
+    "_meta": {
+      "_": "DO NOT UPDATE BY HAND",
+      "version": "17.13.1",
+      "generated_from_framework": "g-cloud-12",
+      "generated_by": "/home/benjamin/code/digitalmarketplace-frameworks/scripts/generate-search-config.py",
+      "generated_time": "2020-09-25T12:26:15.712295",
+      "dm_sort_clause": [
+        "_score",
+        {
+          "sortonly_serviceIdHash": "desc"
         }
+      ],
+      "transformations": [
+        {
+          "hash_to": {
+            "field": "id",
+            "target_field": "serviceIdHash"
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Accounts payable",
+              "Accounts receivable",
+              "Asset management",
+              "Billing and invoicing",
+              "Budgeting",
+              "Contract management",
+              "Debt collection",
+              "Enterprise resource planning (ERP)",
+              "Expense management, expense reporting",
+              "Farming and farm management",
+              "Financial compliance",
+              "Financial management",
+              "Financial risk management",
+              "Land management",
+              "Payment gateway",
+              "Payroll",
+              "Portfolio analysis",
+              "Procurement",
+              "Purchasing",
+              "Revenue cycle management",
+              "Tax management",
+              "Other accounting and finance services"
+            ],
+            "append_value": [
+              "Accounting and finance"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Analytics",
+              "Business intelligence",
+              "Data mining, analysis tools and analytics",
+              "Data visualisation",
+              "Reporting and dashboards"
+            ],
+            "append_value": [
+              "Analytics and business intelligence"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Anti-spam and CAPTCHA",
+              "Audit tools",
+              "Authentication, identity and access management",
+              "Encryption",
+              "Log management",
+              "Remote access",
+              "Secure content and threat management",
+              "Security risk management"
+            ],
+            "append_value": [
+              "Application security"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Blogging",
+              "Booking, scheduling and diary management",
+              "Calendar",
+              "Case management",
+              "Content management system (CMS)",
+              "Content storage and sharing",
+              "Email and secure email",
+              "Enterprise social networking",
+              "File sending and file sharing",
+              "Idea management",
+              "Instant messaging (IM) and chat",
+              "Meeting management",
+              "Online forum or community",
+              "Online meetings",
+              "Presentations and slides (office productivity)",
+              "Project collaboration",
+              "Spreadsheets (office productivity)",
+              "Task management",
+              "Webinars",
+              "Word processing (office productivity)",
+              "Workflow"
+            ],
+            "append_value": [
+              "Collaborative working"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Accessibility checking",
+              "Blogging",
+              "Content management system (CMS)",
+              "Design",
+              "Diagram and wireframe",
+              "Digital publishing",
+              "Online forums",
+              "Photography and multimedia",
+              "Presentations and slides (office productivity)",
+              "Social networking",
+              "Word processing (office productivity)"
+            ],
+            "append_value": [
+              "Creative, design and publishing"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Call centre",
+              "Constituent engagement",
+              "Contact management",
+              "CRM system",
+              "Customer helpdesk (service desk)",
+              "Customer service and support",
+              "Feedback and reviews management",
+              "Forms and surveys",
+              "Live chat",
+              "Partner relationship management (PRM)",
+              "Virtual agents",
+              "Other CRM services"
+            ],
+            "append_value": [
+              "Customer relationship management (CRM)"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Backup, recovery and archival",
+              "Content management system (CMS)",
+              "Document management",
+              "Electronic data interchange (EDI)",
+              "Electronic signatures",
+              "File sending and sharing",
+              "File storage",
+              "Image management and picture archiving"
+            ],
+            "append_value": [
+              "Electronic document and records management (EDRM)"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Assisted living monitoring",
+              "Chiropractic",
+              "Clinical decision support",
+              "Clinical trial management",
+              "Dental",
+              "Electronic medical records",
+              "Healthcare analytics",
+              "Healthcare management",
+              "Home healthcare",
+              "Long-term care",
+              "Medical billing",
+              "Medical imaging",
+              "Medical lab",
+              "Medical practice",
+              "Medical scheduling and booking",
+              "Mental health",
+              "Optometry",
+              "Patient case management, care pathway management",
+              "Pharmacy",
+              "Pharmacy management",
+              "Physical therapy"
+            ],
+            "append_value": [
+              "Healthcare"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Applicant tracking",
+              "Benefits administration",
+              "Culture management",
+              "Employee scheduling",
+              "Employee self-service",
+              "Enterprise social networking",
+              "Examination (applicant testing)",
+              "Holiday planning and absence management",
+              "Payroll",
+              "Performance management",
+              "Recruitment",
+              "Salary",
+              "Talent (retention management)",
+              "Time and expense tracking",
+              "Training",
+              "Workforce analytics",
+              "Workforce management"
+            ],
+            "append_value": [
+              "Human resources and employee management"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "API connectors and interface engines",
+              "Application lifecycle management",
+              "Authentication, identity and access management",
+              "Backup, recovery and archival",
+              "Calendar",
+              "Call accounting",
+              "Call centre",
+              "Configuration and patch management",
+              "Desktop as a Service",
+              "Electronic data interchange (EDI)",
+              "Email and secure email",
+              "Fault management, monitoring and alerting",
+              "Fax",
+              "File sending and file sharing",
+              "File storage",
+              "Forms and surveys",
+              "Geographic information systems and mapping",
+              "Instant messaging (IM) and chat",
+              "Interactive voice response (IVR)",
+              "IT asset management",
+              "Licence management",
+              "Machine learning and artificial intelligence",
+              "Mobile device management",
+              "Natural language and speech processing",
+              "Network services (DNS)",
+              "Online meetings",
+              "Password management",
+              "Performance management",
+              "Post (mailing services)",
+              "Presentations and slides (office productivity)",
+              "Printing",
+              "Security",
+              "SMS",
+              "Spreadsheets (office productivity)",
+              "Systems monitoring",
+              "Telecoms expense management",
+              "Telephony (including VOIP and SIP connectivity)",
+              "Unified communications",
+              "Video conferencing",
+              "Virtual private network (VPN)",
+              "Word processing (office productivity)",
+              "Other information and communications technology (ICT) services"
+            ],
+            "append_value": [
+              "Information and communications technology (ICT)"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Electronic discovery (legal)",
+              "Law enforcement",
+              "Law practice management",
+              "Legal billing",
+              "Legal calendar",
+              "Legal case management",
+              "Legal document management",
+              "Trust accounting"
+            ],
+            "append_value": [
+              "Legal and enforcement"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Advertising",
+              "Affiliate marketing",
+              "Behavioural targeting",
+              "Brand management",
+              "Campaign management",
+              "Community management",
+              "Contextual marketing",
+              "Display advertising",
+              "Email marketing",
+              "Forms and surveys",
+              "Marketing analytics",
+              "Marketing automation",
+              "Marketing data",
+              "Mobile marketing",
+              "Online display advertising",
+              "Personalisation and behavioral targeting",
+              "Public relations",
+              "Search marketing",
+              "Social marketing",
+              "Social media marketing",
+              "Social media monitoring",
+              "Webinars",
+              "Other marketing services"
+            ],
+            "append_value": [
+              "Marketing"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Applications",
+              "Building information modelling (BIM)",
+              "Business management",
+              "Business performance management",
+              "Business process management (BPM)",
+              "Business process modelling (BPM)",
+              "Business transformation and organisational change management",
+              "Carbon, energy and sustainability management",
+              "Complex event processing",
+              "Contract management",
+              "Digital asset management",
+              "Digital signatures",
+              "Enterprise resource planning (ERP)",
+              "Facility management",
+              "Field service management",
+              "Governance, risk management and compliance (GRC)",
+              "Inventory management",
+              "Order management",
+              "Procurement",
+              "Product lifecycle management",
+              "Scheduling and appointments",
+              "Supply chain management",
+              "Visitor management",
+              "Workflow",
+              "Other operations management services"
+            ],
+            "append_value": [
+              "Operations management"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Agile project management and issue tracking",
+              "Professional services automation (PSA)",
+              "Project management",
+              "Project portfolio management (PPM)",
+              "Task management",
+              "Time and expense tracking"
+            ],
+            "append_value": [
+              "Project management and planning"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Configure, price and quote (CPQ)",
+              "eCommerce and shopping cart",
+              "Payment gateway",
+              "Recurring billing and subscription management",
+              "Sales and operations planning",
+              "Sales intelligence tracking",
+              "Sales performance management",
+              "Other sales services"
+            ],
+            "append_value": [
+              "Sales"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Academic",
+              "Alumni management",
+              "Asynchronous learning",
+              "Campus management",
+              "Classroom management",
+              "eLearning",
+              "Examination or applicant testing",
+              "Library automation",
+              "Library management",
+              "Online courses",
+              "Online grading",
+              "School accounting",
+              "School administration",
+              "Student management",
+              "Synchronous learning"
+            ],
+            "append_value": [
+              "Schools, education and libraries"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Accessibility",
+              "Agile project management and issue tracking",
+              "Bug tracking",
+              "Build tools",
+              "Code generation",
+              "Development tools",
+              "Form building",
+              "Integrated development environment (IDE)",
+              "Mobile development",
+              "Search",
+              "Source code management",
+              "Testing and optimisation",
+              "Usability",
+              "Version control",
+              "Website builder"
+            ],
+            "append_value": [
+              "Software development tools"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Airport management",
+              "Aviation maintenance",
+              "Distribution",
+              "Fleet management",
+              "Fleet tracking",
+              "Freight management",
+              "Inventory management",
+              "Marine",
+              "Shipping",
+              "Transportation dispatch",
+              "Trucking solutions",
+              "Warehouse management",
+              "Other transport and logistics services"
+            ],
+            "append_value": [
+              "Transport and logistics"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "planningService",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Planning"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "setupAndMigrationService",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Setup and migration"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "QAAndTesting",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Quality assurance and performance testing"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "securityTesting",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Security services"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "training",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Training"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "ongoingSupport",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Ongoing support"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "emailOrTicketingSupport",
+            "target_field": "emailOrTicketingSupport",
+            "any_of": [
+              "yes_extra_cost"
+            ],
+            "append_value": [
+              "yes"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "webChatSupport",
+            "target_field": "webChatSupport",
+            "any_of": [
+              "yes_extra_cost"
+            ],
+            "append_value": [
+              "yes"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "onsiteSupport",
+            "target_field": "onsiteSupport",
+            "any_of": [
+              "yes_extra_cost"
+            ],
+            "append_value": [
+              "yes"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "dataStorageAndProcessingLocations",
+            "target_field": "dataStorageAndProcessingLocations",
+            "any_of": [
+              "uk"
+            ],
+            "append_value": [
+              "eea"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "dataStorageAndProcessingLocations",
+            "target_field": "dataStorageAndProcessingLocations",
+            "any_of": [
+              "uk",
+              "eea"
+            ],
+            "append_value": [
+              "privacy_shield"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "governmentSecurityClearances",
+            "target_field": "governmentSecurityClearances",
+            "any_of": [
+              "dv",
+              "sc"
+            ],
+            "append_value": [
+              "sc"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "governmentSecurityClearances",
+            "target_field": "governmentSecurityClearances",
+            "any_of": [
+              "dv",
+              "sc",
+              "bpss"
+            ],
+            "append_value": [
+              "bpss"
+            ]
+          }
+        }
+      ]
+    },
+    "dynamic": "strict",
+    "properties": {
+      "dmtext_id": {
+        "type": "keyword"
+      },
+      "sortonly_serviceIdHash": {
+        "type": "keyword"
+      },
+      "dmagg_lot": {
+        "type": "keyword"
+      },
+      "dmtext_lot": {
+        "type": "keyword"
+      },
+      "dmtext_lotName": {
+        "type": "text"
+      },
+      "dmtext_frameworkName": {
+        "type": "keyword"
+      },
+      "dmtext_serviceName": {
+        "type": "text"
+      },
+      "dmtext_serviceDescription": {
+        "term_vector": "with_positions_offsets",
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_serviceBenefits": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_serviceFeatures": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_supplierName": {
+        "type": "text"
+      },
+      "dmfilter_lot": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmagg_serviceCategories": {
+        "type": "keyword"
+      },
+      "dmtext_serviceCategories": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmfilter_serviceCategories": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_cloudDeploymentModel": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_resellingType": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_emailOrTicketingSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_phoneSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_webChatSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_onsiteSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_browsersAccess": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_installation": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_mobile": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_APISoftware": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_metricsHow": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_metricsWhat": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_scalingType": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_usageNotifications": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_backup": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_backupDatacentre": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_publicSectorNetworksTypes": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_dataProtectionBetweenNetworks": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_dataProtectionWithinNetwork": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_dataStorageAndProcessingLocations": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_userAuthentication": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_managementAccessAuthentication": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsISOIEC27001": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsISO28000": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsCSASTAR": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsPCI": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_securityGovernanceStandards": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_datacentreSecurityStandards": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_staffSecurityClearanceChecks": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_governmentSecurityClearances": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_educationPricing": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_freeVersionTrialOption": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
       }
     }
   }

--- a/mappings/services-g-cloud-12.json
+++ b/mappings/services-g-cloud-12.json
@@ -49,6 +49,7 @@
       "_": "DO NOT UPDATE BY HAND",
       "version": "17.13.1",
       "generated_from_framework": "g-cloud-12",
+      "doc_type": "services",
       "generated_by": "/home/benjamin/code/digitalmarketplace-frameworks/scripts/generate-search-config.py",
       "generated_time": "2020-09-25T12:26:15.712295",
       "dm_sort_clause": [

--- a/mappings/services.json
+++ b/mappings/services.json
@@ -8,7 +8,6 @@
         "stemming_analyzer": {
           "tokenizer": "standard",
           "filter": [
-            "standard",
             "lowercase",
             "possessive_english_stemmer",
             "light_english_stemmer"

--- a/mappings/services.json
+++ b/mappings/services.json
@@ -49,6 +49,7 @@
       "_": "DO NOT UPDATE BY HAND",
       "version": "10.2.1",
       "generated_from_framework": "g-cloud-9",
+      "doc_type": "services",
       "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
       "generated_time": "2018-01-17T15:53:05.466593",
       "dm_sort_clause": [

--- a/mappings/services.json
+++ b/mappings/services.json
@@ -45,831 +45,829 @@
     }
   },
   "mappings": {
-    "services": {
-      "_meta": {
-        "_": "DO NOT UPDATE BY HAND",
-        "version": "10.2.1",
-        "generated_from_framework": "g-cloud-9",
-        "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
-        "generated_time": "2018-01-17T15:53:05.466593",
-        "dm_sort_clause": [
-          "_score",
-          {
-            "sortonly_serviceIdHash": "desc"
-          }
-        ],
-        "transformations": [
-          {
-            "hash_to": {
-              "field": "id",
-              "target_field": "serviceIdHash"
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Accounts payable",
-                "Accounts receivable",
-                "Asset management",
-                "Billing and invoicing",
-                "Budgeting",
-                "Contract management",
-                "Debt collection",
-                "Enterprise resource planning (ERP)",
-                "Expense management, expense reporting",
-                "Farming and farm management",
-                "Financial compliance",
-                "Financial management",
-                "Financial risk management",
-                "Land management",
-                "Payment gateway",
-                "Payroll",
-                "Portfolio analysis",
-                "Procurement",
-                "Purchasing",
-                "Revenue cycle management",
-                "Tax management",
-                "Other accounting and finance services"
-              ],
-              "append_value": [
-                "Accounting and finance"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Analytics",
-                "Business intelligence",
-                "Data mining, analysis tools and analytics",
-                "Data visualisation",
-                "Reporting and dashboards"
-              ],
-              "append_value": [
-                "Analytics and business intelligence"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Anti-spam and CAPTCHA",
-                "Audit tools",
-                "Authentication, identity and access management",
-                "Encryption",
-                "Log management",
-                "Remote access",
-                "Secure content and threat management",
-                "Security risk management"
-              ],
-              "append_value": [
-                "Application security"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Blogging",
-                "Booking, scheduling and diary management",
-                "Calendar",
-                "Case management",
-                "Content management system (CMS)",
-                "Content storage and sharing",
-                "Email and secure email",
-                "Enterprise social networking",
-                "File sending and file sharing",
-                "Idea management",
-                "Instant messaging (IM) and chat",
-                "Meeting management",
-                "Online forum or community",
-                "Online meetings",
-                "Presentations and slides (office productivity)",
-                "Project collaboration",
-                "Spreadsheets (office productivity)",
-                "Task management",
-                "Webinars",
-                "Word processing (office productivity)",
-                "Workflow"
-              ],
-              "append_value": [
-                "Collaborative working"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Accessibility checking",
-                "Blogging",
-                "Content management system (CMS)",
-                "Design",
-                "Diagram and wireframe",
-                "Digital publishing",
-                "Online forums",
-                "Photography and multimedia",
-                "Presentations and slides (office productivity)",
-                "Social networking",
-                "Word processing (office productivity)"
-              ],
-              "append_value": [
-                "Creative, design and publishing"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Call centre",
-                "Constituent engagement",
-                "Contact management",
-                "CRM system",
-                "Customer helpdesk (service desk)",
-                "Customer service and support",
-                "Feedback and reviews management",
-                "Forms and surveys",
-                "Live chat",
-                "Partner relationship management (PRM)",
-                "Virtual agents",
-                "Other CRM services"
-              ],
-              "append_value": [
-                "Customer relationship management (CRM)"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Backup, recovery and archival",
-                "Content management system (CMS)",
-                "Document management",
-                "Electronic data interchange (EDI)",
-                "Electronic signatures",
-                "File sending and sharing",
-                "File storage",
-                "Image management and picture archiving"
-              ],
-              "append_value": [
-                "Electronic document and records management (EDRM)"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Assisted living monitoring",
-                "Chiropractic",
-                "Clinical decision support",
-                "Clinical trial management",
-                "Dental",
-                "Electronic medical records",
-                "Healthcare analytics",
-                "Healthcare management",
-                "Home healthcare",
-                "Long-term care",
-                "Medical billing",
-                "Medical imaging",
-                "Medical lab",
-                "Medical practice",
-                "Medical scheduling and booking",
-                "Mental health",
-                "Optometry",
-                "Patient case management, care pathway management",
-                "Pharmacy",
-                "Pharmacy management",
-                "Physical therapy"
-              ],
-              "append_value": [
-                "Healthcare"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Applicant tracking",
-                "Benefits administration",
-                "Culture management",
-                "Employee scheduling",
-                "Employee self-service",
-                "Enterprise social networking",
-                "Examination (applicant testing)",
-                "Holiday planning and absence management",
-                "Payroll",
-                "Performance management",
-                "Recruitment",
-                "Salary",
-                "Talent (retention management)",
-                "Time and expense tracking",
-                "Training",
-                "Workforce analytics",
-                "Workforce management"
-              ],
-              "append_value": [
-                "Human resources and employee management"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "API connectors and interface engines",
-                "Application lifecycle management",
-                "Authentication, identity and access management",
-                "Backup, recovery and archival",
-                "Calendar",
-                "Call accounting",
-                "Call centre",
-                "Configuration and patch management",
-                "Desktop as a Service",
-                "Electronic data interchange (EDI)",
-                "Email and secure email",
-                "Fault management, monitoring and alerting",
-                "Fax",
-                "File sending and file sharing",
-                "File storage",
-                "Forms and surveys",
-                "Geographic information systems and mapping",
-                "Instant messaging (IM) and chat",
-                "Interactive voice response (IVR)",
-                "IT asset management",
-                "Licence management",
-                "Machine learning and artificial intelligence",
-                "Mobile device management",
-                "Natural language and speech processing",
-                "Network services (DNS)",
-                "Online meetings",
-                "Password management",
-                "Performance management",
-                "Post (mailing services)",
-                "Presentations and slides (office productivity)",
-                "Printing",
-                "Security",
-                "SMS",
-                "Spreadsheets (office productivity)",
-                "Systems monitoring",
-                "Telecoms expense management",
-                "Telephony (including VOIP and SIP connectivity)",
-                "Unified communications",
-                "Video conferencing",
-                "Virtual private network (VPN)",
-                "Word processing (office productivity)",
-                "Other information and communications technology (ICT) services"
-              ],
-              "append_value": [
-                "Information and communications technology (ICT)"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Electronic discovery (legal)",
-                "Law enforcement",
-                "Law practice management",
-                "Legal billing",
-                "Legal calendar",
-                "Legal case management",
-                "Legal document management",
-                "Trust accounting"
-              ],
-              "append_value": [
-                "Legal and enforcement"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Advertising",
-                "Affiliate marketing",
-                "Behavioural targeting",
-                "Brand management",
-                "Campaign management",
-                "Community management",
-                "Contextual marketing",
-                "Display advertising",
-                "Email marketing",
-                "Forms and surveys",
-                "Marketing analytics",
-                "Marketing automation",
-                "Marketing data",
-                "Mobile marketing",
-                "Online display advertising",
-                "Personalisation and behavioral targeting",
-                "Public relations",
-                "Search marketing",
-                "Social marketing",
-                "Social media marketing",
-                "Social media monitoring",
-                "Webinars",
-                "Other marketing services"
-              ],
-              "append_value": [
-                "Marketing"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Applications",
-                "Building information modelling (BIM)",
-                "Business management",
-                "Business performance management",
-                "Business process management (BPM)",
-                "Business process modelling (BPM)",
-                "Business transformation and organisational change management",
-                "Carbon, energy and sustainability management",
-                "Complex event processing",
-                "Contract management",
-                "Digital asset management",
-                "Digital signatures",
-                "Enterprise resource planning (ERP)",
-                "Facility management",
-                "Field service management",
-                "Governance, risk management and compliance (GRC)",
-                "Inventory management",
-                "Order management",
-                "Procurement",
-                "Product lifecycle management",
-                "Scheduling and appointments",
-                "Supply chain management",
-                "Visitor management",
-                "Workflow",
-                "Other operations management services"
-              ],
-              "append_value": [
-                "Operations management"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Agile project management and issue tracking",
-                "Professional services automation (PSA)",
-                "Project management",
-                "Project portfolio management (PPM)",
-                "Task management",
-                "Time and expense tracking"
-              ],
-              "append_value": [
-                "Project management and planning"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Configure, price and quote (CPQ)",
-                "eCommerce and shopping cart",
-                "Payment gateway",
-                "Recurring billing and subscription management",
-                "Sales and operations planning",
-                "Sales intelligence tracking",
-                "Sales performance management",
-                "Other sales services"
-              ],
-              "append_value": [
-                "Sales"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Academic",
-                "Alumni management",
-                "Asynchronous learning",
-                "Campus management",
-                "Classroom management",
-                "eLearning",
-                "Examination or applicant testing",
-                "Library automation",
-                "Library management",
-                "Online courses",
-                "Online grading",
-                "School accounting",
-                "School administration",
-                "Student management",
-                "Synchronous learning"
-              ],
-              "append_value": [
-                "Schools, education and libraries"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Accessibility",
-                "Agile project management and issue tracking",
-                "Bug tracking",
-                "Build tools",
-                "Code generation",
-                "Development tools",
-                "Form building",
-                "Integrated development environment (IDE)",
-                "Mobile development",
-                "Search",
-                "Source code management",
-                "Testing and optimisation",
-                "Usability",
-                "Version control",
-                "Website builder"
-              ],
-              "append_value": [
-                "Software development tools"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "serviceCategories",
-              "any_of": [
-                "Airport management",
-                "Aviation maintenance",
-                "Distribution",
-                "Fleet management",
-                "Fleet tracking",
-                "Freight management",
-                "Inventory management",
-                "Marine",
-                "Shipping",
-                "Transportation dispatch",
-                "Trucking solutions",
-                "Warehouse management",
-                "Other transport and logistics services"
-              ],
-              "append_value": [
-                "Transport and logistics"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "setupAndMigrationService",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Planning"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "setupAndMigrationService",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Setup and migration"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "QAAndTesting",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Quality assurance and performance testing"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "securityTesting",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Security testing"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "training",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Training"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "ongoingSupport",
-              "target_field": "serviceCategories",
-              "any_of": [
-                true
-              ],
-              "append_value": [
-                "Ongoing support"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "emailOrTicketingSupport",
-              "target_field": "emailOrTicketingSupport",
-              "any_of": [
-                "yes_extra_cost"
-              ],
-              "append_value": [
-                "yes"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "webChatSupport",
-              "target_field": "webChatSupport",
-              "any_of": [
-                "yes_extra_cost"
-              ],
-              "append_value": [
-                "yes"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "onsiteSupport",
-              "target_field": "onsiteSupport",
-              "any_of": [
-                "yes_extra_cost"
-              ],
-              "append_value": [
-                "yes"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "dataStorageAndProcessingLocations",
-              "target_field": "dataStorageAndProcessingLocations",
-              "any_of": [
-                "uk"
-              ],
-              "append_value": [
-                "eea"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "dataStorageAndProcessingLocations",
-              "target_field": "dataStorageAndProcessingLocations",
-              "any_of": [
-                "uk",
-                "eea"
-              ],
-              "append_value": [
-                "privacy_shield"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "governmentSecurityClearances",
-              "target_field": "governmentSecurityClearances",
-              "any_of": [
-                "dv",
-                "sc"
-              ],
-              "append_value": [
-                "sc"
-              ]
-            }
-          },
-          {
-            "append_conditionally": {
-              "field": "governmentSecurityClearances",
-              "target_field": "governmentSecurityClearances",
-              "any_of": [
-                "dv",
-                "sc",
-                "bpss"
-              ],
-              "append_value": [
-                "bpss"
-              ]
-            }
-          }
-        ]
-      },
-      "dynamic": "strict",
-      "properties": {
-        "dmtext_id": {
-          "type": "keyword"
-        },
-        "sortonly_serviceIdHash": {
-          "type": "keyword",
-          "include_in_all": false
-        },
-        "dmagg_lot": {
-          "type": "keyword"
-        },
-        "dmtext_lot": {
-          "type": "keyword"
-        },
-        "dmtext_lotName": {
-          "type": "text"
-        },
-        "dmtext_frameworkName": {
-          "type": "keyword"
-        },
-        "dmtext_serviceName": {
-          "type": "text"
-        },
-        "dmtext_serviceDescription": {
-          "term_vector": "with_positions_offsets",
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_serviceBenefits": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_serviceFeatures": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmtext_supplierName": {
-          "type": "text"
-        },
-        "dmfilter_lot": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmagg_serviceCategories": {
-          "type": "keyword"
-        },
-        "dmtext_serviceCategories": {
-          "type": "text",
-          "analyzer": "stemming_analyzer"
-        },
-        "dmfilter_serviceCategories": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_cloudDeploymentModel": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_resellingType": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_emailOrTicketingSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_phoneSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_webChatSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_onsiteSupport": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_browsersAccess": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_installation": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_mobile": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_APISoftware": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_metricsHow": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_metricsWhat": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_scalingType": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_usageNotifications": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_backup": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_backupDatacentre": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_publicSectorNetworksTypes": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_dataProtectionBetweenNetworks": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_dataProtectionWithinNetwork": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_dataStorageAndProcessingLocations": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_userAuthentication": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_managementAccessAuthentication": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsISOIEC27001": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsISO28000": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsCSASTAR": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_standardsPCI": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_securityGovernanceStandards": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_datacentreSecurityStandards": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_staffSecurityClearanceChecks": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_governmentSecurityClearances": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_educationPricing": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
-        },
-        "dmfilter_freeVersionTrialOption": {
-          "type": "keyword",
-          "normalizer": "filter_normalizer"
+    "_meta": {
+      "_": "DO NOT UPDATE BY HAND",
+      "version": "10.2.1",
+      "generated_from_framework": "g-cloud-9",
+      "generated_by": "digitalmarketplace-frameworks/scripts/generate-search-config.py",
+      "generated_time": "2018-01-17T15:53:05.466593",
+      "dm_sort_clause": [
+        "_score",
+        {
+          "sortonly_serviceIdHash": "desc"
         }
+      ],
+      "transformations": [
+        {
+          "hash_to": {
+            "field": "id",
+            "target_field": "serviceIdHash"
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Accounts payable",
+              "Accounts receivable",
+              "Asset management",
+              "Billing and invoicing",
+              "Budgeting",
+              "Contract management",
+              "Debt collection",
+              "Enterprise resource planning (ERP)",
+              "Expense management, expense reporting",
+              "Farming and farm management",
+              "Financial compliance",
+              "Financial management",
+              "Financial risk management",
+              "Land management",
+              "Payment gateway",
+              "Payroll",
+              "Portfolio analysis",
+              "Procurement",
+              "Purchasing",
+              "Revenue cycle management",
+              "Tax management",
+              "Other accounting and finance services"
+            ],
+            "append_value": [
+              "Accounting and finance"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Analytics",
+              "Business intelligence",
+              "Data mining, analysis tools and analytics",
+              "Data visualisation",
+              "Reporting and dashboards"
+            ],
+            "append_value": [
+              "Analytics and business intelligence"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Anti-spam and CAPTCHA",
+              "Audit tools",
+              "Authentication, identity and access management",
+              "Encryption",
+              "Log management",
+              "Remote access",
+              "Secure content and threat management",
+              "Security risk management"
+            ],
+            "append_value": [
+              "Application security"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Blogging",
+              "Booking, scheduling and diary management",
+              "Calendar",
+              "Case management",
+              "Content management system (CMS)",
+              "Content storage and sharing",
+              "Email and secure email",
+              "Enterprise social networking",
+              "File sending and file sharing",
+              "Idea management",
+              "Instant messaging (IM) and chat",
+              "Meeting management",
+              "Online forum or community",
+              "Online meetings",
+              "Presentations and slides (office productivity)",
+              "Project collaboration",
+              "Spreadsheets (office productivity)",
+              "Task management",
+              "Webinars",
+              "Word processing (office productivity)",
+              "Workflow"
+            ],
+            "append_value": [
+              "Collaborative working"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Accessibility checking",
+              "Blogging",
+              "Content management system (CMS)",
+              "Design",
+              "Diagram and wireframe",
+              "Digital publishing",
+              "Online forums",
+              "Photography and multimedia",
+              "Presentations and slides (office productivity)",
+              "Social networking",
+              "Word processing (office productivity)"
+            ],
+            "append_value": [
+              "Creative, design and publishing"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Call centre",
+              "Constituent engagement",
+              "Contact management",
+              "CRM system",
+              "Customer helpdesk (service desk)",
+              "Customer service and support",
+              "Feedback and reviews management",
+              "Forms and surveys",
+              "Live chat",
+              "Partner relationship management (PRM)",
+              "Virtual agents",
+              "Other CRM services"
+            ],
+            "append_value": [
+              "Customer relationship management (CRM)"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Backup, recovery and archival",
+              "Content management system (CMS)",
+              "Document management",
+              "Electronic data interchange (EDI)",
+              "Electronic signatures",
+              "File sending and sharing",
+              "File storage",
+              "Image management and picture archiving"
+            ],
+            "append_value": [
+              "Electronic document and records management (EDRM)"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Assisted living monitoring",
+              "Chiropractic",
+              "Clinical decision support",
+              "Clinical trial management",
+              "Dental",
+              "Electronic medical records",
+              "Healthcare analytics",
+              "Healthcare management",
+              "Home healthcare",
+              "Long-term care",
+              "Medical billing",
+              "Medical imaging",
+              "Medical lab",
+              "Medical practice",
+              "Medical scheduling and booking",
+              "Mental health",
+              "Optometry",
+              "Patient case management, care pathway management",
+              "Pharmacy",
+              "Pharmacy management",
+              "Physical therapy"
+            ],
+            "append_value": [
+              "Healthcare"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Applicant tracking",
+              "Benefits administration",
+              "Culture management",
+              "Employee scheduling",
+              "Employee self-service",
+              "Enterprise social networking",
+              "Examination (applicant testing)",
+              "Holiday planning and absence management",
+              "Payroll",
+              "Performance management",
+              "Recruitment",
+              "Salary",
+              "Talent (retention management)",
+              "Time and expense tracking",
+              "Training",
+              "Workforce analytics",
+              "Workforce management"
+            ],
+            "append_value": [
+              "Human resources and employee management"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "API connectors and interface engines",
+              "Application lifecycle management",
+              "Authentication, identity and access management",
+              "Backup, recovery and archival",
+              "Calendar",
+              "Call accounting",
+              "Call centre",
+              "Configuration and patch management",
+              "Desktop as a Service",
+              "Electronic data interchange (EDI)",
+              "Email and secure email",
+              "Fault management, monitoring and alerting",
+              "Fax",
+              "File sending and file sharing",
+              "File storage",
+              "Forms and surveys",
+              "Geographic information systems and mapping",
+              "Instant messaging (IM) and chat",
+              "Interactive voice response (IVR)",
+              "IT asset management",
+              "Licence management",
+              "Machine learning and artificial intelligence",
+              "Mobile device management",
+              "Natural language and speech processing",
+              "Network services (DNS)",
+              "Online meetings",
+              "Password management",
+              "Performance management",
+              "Post (mailing services)",
+              "Presentations and slides (office productivity)",
+              "Printing",
+              "Security",
+              "SMS",
+              "Spreadsheets (office productivity)",
+              "Systems monitoring",
+              "Telecoms expense management",
+              "Telephony (including VOIP and SIP connectivity)",
+              "Unified communications",
+              "Video conferencing",
+              "Virtual private network (VPN)",
+              "Word processing (office productivity)",
+              "Other information and communications technology (ICT) services"
+            ],
+            "append_value": [
+              "Information and communications technology (ICT)"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Electronic discovery (legal)",
+              "Law enforcement",
+              "Law practice management",
+              "Legal billing",
+              "Legal calendar",
+              "Legal case management",
+              "Legal document management",
+              "Trust accounting"
+            ],
+            "append_value": [
+              "Legal and enforcement"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Advertising",
+              "Affiliate marketing",
+              "Behavioural targeting",
+              "Brand management",
+              "Campaign management",
+              "Community management",
+              "Contextual marketing",
+              "Display advertising",
+              "Email marketing",
+              "Forms and surveys",
+              "Marketing analytics",
+              "Marketing automation",
+              "Marketing data",
+              "Mobile marketing",
+              "Online display advertising",
+              "Personalisation and behavioral targeting",
+              "Public relations",
+              "Search marketing",
+              "Social marketing",
+              "Social media marketing",
+              "Social media monitoring",
+              "Webinars",
+              "Other marketing services"
+            ],
+            "append_value": [
+              "Marketing"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Applications",
+              "Building information modelling (BIM)",
+              "Business management",
+              "Business performance management",
+              "Business process management (BPM)",
+              "Business process modelling (BPM)",
+              "Business transformation and organisational change management",
+              "Carbon, energy and sustainability management",
+              "Complex event processing",
+              "Contract management",
+              "Digital asset management",
+              "Digital signatures",
+              "Enterprise resource planning (ERP)",
+              "Facility management",
+              "Field service management",
+              "Governance, risk management and compliance (GRC)",
+              "Inventory management",
+              "Order management",
+              "Procurement",
+              "Product lifecycle management",
+              "Scheduling and appointments",
+              "Supply chain management",
+              "Visitor management",
+              "Workflow",
+              "Other operations management services"
+            ],
+            "append_value": [
+              "Operations management"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Agile project management and issue tracking",
+              "Professional services automation (PSA)",
+              "Project management",
+              "Project portfolio management (PPM)",
+              "Task management",
+              "Time and expense tracking"
+            ],
+            "append_value": [
+              "Project management and planning"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Configure, price and quote (CPQ)",
+              "eCommerce and shopping cart",
+              "Payment gateway",
+              "Recurring billing and subscription management",
+              "Sales and operations planning",
+              "Sales intelligence tracking",
+              "Sales performance management",
+              "Other sales services"
+            ],
+            "append_value": [
+              "Sales"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Academic",
+              "Alumni management",
+              "Asynchronous learning",
+              "Campus management",
+              "Classroom management",
+              "eLearning",
+              "Examination or applicant testing",
+              "Library automation",
+              "Library management",
+              "Online courses",
+              "Online grading",
+              "School accounting",
+              "School administration",
+              "Student management",
+              "Synchronous learning"
+            ],
+            "append_value": [
+              "Schools, education and libraries"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Accessibility",
+              "Agile project management and issue tracking",
+              "Bug tracking",
+              "Build tools",
+              "Code generation",
+              "Development tools",
+              "Form building",
+              "Integrated development environment (IDE)",
+              "Mobile development",
+              "Search",
+              "Source code management",
+              "Testing and optimisation",
+              "Usability",
+              "Version control",
+              "Website builder"
+            ],
+            "append_value": [
+              "Software development tools"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "serviceCategories",
+            "any_of": [
+              "Airport management",
+              "Aviation maintenance",
+              "Distribution",
+              "Fleet management",
+              "Fleet tracking",
+              "Freight management",
+              "Inventory management",
+              "Marine",
+              "Shipping",
+              "Transportation dispatch",
+              "Trucking solutions",
+              "Warehouse management",
+              "Other transport and logistics services"
+            ],
+            "append_value": [
+              "Transport and logistics"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "setupAndMigrationService",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Planning"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "setupAndMigrationService",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Setup and migration"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "QAAndTesting",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Quality assurance and performance testing"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "securityTesting",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Security testing"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "training",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Training"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "ongoingSupport",
+            "target_field": "serviceCategories",
+            "any_of": [
+              true
+            ],
+            "append_value": [
+              "Ongoing support"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "emailOrTicketingSupport",
+            "target_field": "emailOrTicketingSupport",
+            "any_of": [
+              "yes_extra_cost"
+            ],
+            "append_value": [
+              "yes"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "webChatSupport",
+            "target_field": "webChatSupport",
+            "any_of": [
+              "yes_extra_cost"
+            ],
+            "append_value": [
+              "yes"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "onsiteSupport",
+            "target_field": "onsiteSupport",
+            "any_of": [
+              "yes_extra_cost"
+            ],
+            "append_value": [
+              "yes"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "dataStorageAndProcessingLocations",
+            "target_field": "dataStorageAndProcessingLocations",
+            "any_of": [
+              "uk"
+            ],
+            "append_value": [
+              "eea"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "dataStorageAndProcessingLocations",
+            "target_field": "dataStorageAndProcessingLocations",
+            "any_of": [
+              "uk",
+              "eea"
+            ],
+            "append_value": [
+              "privacy_shield"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "governmentSecurityClearances",
+            "target_field": "governmentSecurityClearances",
+            "any_of": [
+              "dv",
+              "sc"
+            ],
+            "append_value": [
+              "sc"
+            ]
+          }
+        },
+        {
+          "append_conditionally": {
+            "field": "governmentSecurityClearances",
+            "target_field": "governmentSecurityClearances",
+            "any_of": [
+              "dv",
+              "sc",
+              "bpss"
+            ],
+            "append_value": [
+              "bpss"
+            ]
+          }
+        }
+      ]
+    },
+    "dynamic": "strict",
+    "properties": {
+      "dmtext_id": {
+        "type": "keyword"
+      },
+      "sortonly_serviceIdHash": {
+        "type": "keyword",
+        "include_in_all": false
+      },
+      "dmagg_lot": {
+        "type": "keyword"
+      },
+      "dmtext_lot": {
+        "type": "keyword"
+      },
+      "dmtext_lotName": {
+        "type": "text"
+      },
+      "dmtext_frameworkName": {
+        "type": "keyword"
+      },
+      "dmtext_serviceName": {
+        "type": "text"
+      },
+      "dmtext_serviceDescription": {
+        "term_vector": "with_positions_offsets",
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_serviceBenefits": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_serviceFeatures": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmtext_supplierName": {
+        "type": "text"
+      },
+      "dmfilter_lot": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmagg_serviceCategories": {
+        "type": "keyword"
+      },
+      "dmtext_serviceCategories": {
+        "type": "text",
+        "analyzer": "stemming_analyzer"
+      },
+      "dmfilter_serviceCategories": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_cloudDeploymentModel": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_resellingType": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_emailOrTicketingSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_phoneSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_webChatSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_onsiteSupport": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_browsersAccess": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_installation": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_mobile": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_APISoftware": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_metricsHow": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_metricsWhat": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_scalingType": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_usageNotifications": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_backup": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_backupDatacentre": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_publicSectorNetworksTypes": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_dataProtectionBetweenNetworks": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_dataProtectionWithinNetwork": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_dataStorageAndProcessingLocations": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_userAuthentication": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_managementAccessAuthentication": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsISOIEC27001": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsISO28000": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsCSASTAR": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_standardsPCI": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_securityGovernanceStandards": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_datacentreSecurityStandards": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_staffSecurityClearanceChecks": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_governmentSecurityClearances": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_educationPricing": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
+      },
+      "dmfilter_freeVersionTrialOption": {
+        "type": "keyword",
+        "normalizer": "filter_normalizer"
       }
     }
   }

--- a/requirements.in
+++ b/requirements.in
@@ -7,5 +7,5 @@ itsdangerous==1.1.0  # pyup: ignore
 git+https://github.com/alphagov/digitalmarketplace-utils.git@54.1.1#egg=digitalmarketplace-utils==54.1.1
 
 # Elasticsearch 5.0
-elasticsearch==6.8.1 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
+elasticsearch==7.9.1 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
 Flask-Elasticsearch==0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 blinker==1.4              # via gds-metrics
 boto3==1.12.3             # via digitalmarketplace-utils
 botocore==1.15.3          # via boto3, s3transfer
-certifi==2019.11.28       # via requests
+certifi==2019.11.28       # via elasticsearch, requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via flask
@@ -17,7 +17,7 @@ defusedxml==0.6.0         # via odfpy
 git+https://github.com/alphagov/digitalmarketplace-utils.git@54.1.1#egg=digitalmarketplace-utils==54.1.1  # via -r requirements.in
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore
-elasticsearch==6.8.1      # via -r requirements.in, flask-elasticsearch
+elasticsearch==7.9.1      # via -r requirements.in, flask-elasticsearch
 flask-elasticsearch==0.2.5  # via -r requirements.in
 flask-gzip==0.2           # via digitalmarketplace-utils
 flask-login==0.5.0        # via digitalmarketplace-utils

--- a/tests/app/views/test_admin.py
+++ b/tests/app/views/test_admin.py
@@ -77,7 +77,7 @@ class TestSearchIndexes(BaseApplicationTest):
 
         expected_string = (
             'invalid_alias_name_exception: Invalid alias name [test-index], an index exists with the same name '
-            'as the alias (test-index)'
+            'as the alias'
         )
         assert response.json["error"] == expected_string
 
@@ -112,14 +112,14 @@ class TestSearchIndexes(BaseApplicationTest):
         self.client.delete('/test-index')
         response = self.client.delete('/test-index')
         assert response.status_code == 404
-        assert response.json["error"] == 'index_not_found_exception: no such index (test-index)'
+        assert response.json["error"] == 'index_not_found_exception: no such index [test-index]'
 
     def test_should_return_404_if_no_index(self):
         response = self.client.get('/index-does-not-exist')
         assert response.status_code == 404
         assert (
             response.json["error"] ==
-            "index_not_found_exception: no such index (index-does-not-exist)"
+            "index_not_found_exception: no such index [index-does-not-exist]"
         )
 
     def test_bad_mapping_name_gives_400(self):

--- a/tests/app/views/test_meta.py
+++ b/tests/app/views/test_meta.py
@@ -17,7 +17,7 @@ class TestMeta(BaseApplicationTestWithIndex):
 
             elasticsearch_client.indices.create(
                 index=".dot-index",
-                body=json.dumps({"mappings": {"mapping": {}}})
+                body=json.dumps({"mappings": {}})
             )
             self.client.put('/dot-index-alias', data=json.dumps({
                 "type": "alias",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -65,7 +65,7 @@ class BaseApplicationTest(object):
             "mapping": self.default_mapping_name,
         }), content_type="application/json")
         if expect_success:
-            assert response.status_code in (200, 201)
+            assert response.status_code in (200, 201), response.json["error"]
         return response
 
     def teardown(self):


### PR DESCRIPTION
Update the search API to support Elasticsearch 7. Our hosting provider has deemed ES6 EOL and will upgrade our current ES6 instances to ES7 on November 20th if we don't do it before then. 

This is effectively a **breaking change** - this version of the search API will not work on our existing ES6 instances as it expects changes to the index mappings which are not compatible with ES6. All API routes and data are the same however, so our API client will not need changing.

To migrate from the current search API and ES6 we'll need to follow a similar process to when we migrated to ES6 as detailed in [this card](https://trello.com/c/Yh8uyxvF/2102-migrate-elasticsearch-on-preview)

In order to make the API changes we have updated the mapping JSON files in this repo which are generated in [the frameworks repo](https://github.com/alphagov/digitalmarketplace-frameworks). We're aware that we'll need to update the code which generates them as well.

This is quite a large PR and when reviewing we recommend going through each commit and viewing diffs without whitespace changes - especially for the JSON files. Commit messages have links to ES7 documentation where appropriate.

https://trello.com/c/lHGzb0vH/2060-upgrade-elasticsearch-to-version-7-as-aiven-will-eol-version-6-on-20-november-2020