### PR TITLE
Update search mappings from digitalmarketplace-frameworks@18.0.0

### DIFF
--- a/mappings/briefs-digital-outcomes-and-specialists-2.json
+++ b/mappings/briefs-digital-outcomes-and-specialists-2.json
@@ -47,11 +47,11 @@
   "mappings": {
     "_meta": {
       "_": "DO NOT UPDATE BY HAND",
-      "version": "11.0.0",
-      "generated_from_framework": "digital-outcomes-and-specialists-2",
+      "version": "18.0.0",
+      "generated_from_framework": "digital-outcomes-and-specialists-4",
       "doc_type": "briefs",
-      "generated_by": "/Users/brendanbutler/digitalmarketplace/digitalmarketplace-frameworks/scripts/generate-search-config.py",
-      "generated_time": "2018-03-13T14:53:51.783965",
+      "generated_by": "/Users/laurencedebruxelles/Code/digitalmarketplace/digitalmarketplace-frameworks/scripts/generate-search-config.py",
+      "generated_time": "2020-11-19T09:04:32.493419",
       "dm_sort_clause": [
         "sortonly_statusOrder",
         {

--- a/mappings/services-g-cloud-12.json
+++ b/mappings/services-g-cloud-12.json
@@ -47,11 +47,11 @@
   "mappings": {
     "_meta": {
       "_": "DO NOT UPDATE BY HAND",
-      "version": "17.13.1",
+      "version": "18.0.0",
       "generated_from_framework": "g-cloud-12",
       "doc_type": "services",
-      "generated_by": "/home/benjamin/code/digitalmarketplace-frameworks/scripts/generate-search-config.py",
-      "generated_time": "2020-09-25T12:26:15.712295",
+      "generated_by": "/Users/laurencedebruxelles/Code/digitalmarketplace/digitalmarketplace-frameworks/scripts/generate-search-config.py",
+      "generated_time": "2020-11-19T08:50:53.956076",
       "dm_sort_clause": [
         "_score",
         {


### PR DESCRIPTION
Ticket: https://trello.com/c/Yh8uyxvF/2102-migrate-elasticsearch-on-preview

Update the search mappings for DOS and G-Cloud 12 using the changes in
alphagov/digitalmarketplace-frameworks#653.