### PR TITLE
Replace make with invoke

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,3 +14,4 @@ per-file-ignores =
     app/__init__.py : F401
     app/main/__init__.py : F401, E402
     app/status/__init__.py : F401, E402
+    tasks.py: F401

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,34 +9,39 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-      - name: Setup python (${{ matrix.python-version }})
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
+    - name: Setup python (${{ matrix.python-version }})
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
 
-      - name: Setup Python cache
-        uses: actions/cache@v2
-        with:
-          path: venv
-          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
+    - name: Setup Python cache
+      uses: actions/cache@v2
+      id: python-cache
+      with:
+        path: venv
+        key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
+        restore-keys: venv-${{ runner.os }}-${{ matrix.python-version }}-
+    # See https://github.com/elastic/elastic-github-actions/tree/master/elasticsearch
+    - name: Configure sysctl limits
+      run: |
+        sudo swapoff -a
+        sudo sysctl -w vm.swappiness=1
+        sudo sysctl -w fs.file-max=262144
+        sudo sysctl -w vm.max_map_count=262144
 
-      # See https://github.com/elastic/elastic-github-actions/tree/master/elasticsearch
-      - name: Configure sysctl limits
-        run: |
-          sudo swapoff -a
-          sudo sysctl -w vm.swappiness=1
-          sudo sysctl -w fs.file-max=262144
-          sudo sysctl -w vm.max_map_count=262144
+    - name: Run Elasticsearch
+      uses: elastic/elastic-github-actions/elasticsearch@531c232fb9ea0217d7f517f10d1970d76b0e847e
+      with:
+        stack-version: 7.9.3
 
-      - name: Run Elasticsearch
-        uses: elastic/elastic-github-actions/elasticsearch@531c232fb9ea0217d7f517f10d1970d76b0e847e
-        with:
-          stack-version: 7.9.3
+    - name: Install developer tools
+      run: make bootstrap
 
-      - name: Install packages and run tests
-        run: |
-          make requirements-dev
-          make test
+    - name: Install python dependencies
+      run: invoke requirements-dev
+      if: steps.python-cache.outputs.cache-hit != 'true'
+
+    - name: Run python tests
+      run: invoke test

--- a/Makefile
+++ b/Makefile
@@ -1,53 +1,21 @@
-SHELL := /bin/bash
-VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 
-.PHONY: run-all
-run-all: requirements run-app
+.DEFAULT_GOAL := bootstrap
 
-.PHONY: run-app
-run-app: virtualenv
-	${VIRTUALENV_ROOT}/bin/flask run
+%:
+	-@[ -z "$$TERM" ] || tput setaf 1  # red
+	@>&2 echo warning: calling '`make`' is being deprecated in this repo, you should use '`invoke` (https://pyinvoke.org)' instead.
+	-@[ -z "$$TERM" ] || tput setaf 9  # default
+	@# pass goals to '`invoke`'
+	invoke $(or $(MAKECMDGOALS), $@)
+	@exit
 
-.PHONY: virtualenv
-virtualenv:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
+help:
+	invoke --list
 
-.PHONY: upgrade-pip
-upgrade-pip: virtualenv
-	${VIRTUALENV_ROOT}/bin/pip install --upgrade pip
-
-.PHONY: requirements
-requirements: virtualenv upgrade-pip requirements.txt
-	${VIRTUALENV_ROOT}/bin/pip install -r requirements.txt
-
-.PHONY: requirements-dev
-requirements-dev: virtualenv upgrade-pip requirements.txt requirements-dev.txt
-	${VIRTUALENV_ROOT}/bin/pip install -r requirements.txt -r requirements-dev.txt
-
-.PHONY: freeze-requirements
-freeze-requirements: virtualenv requirements-dev requirements.in requirements-dev.in
-	${VIRTUALENV_ROOT}/bin/pip-compile requirements.in
-	${VIRTUALENV_ROOT}/bin/pip-compile requirements-dev.in
-
-.PHONY: test
-test: test-flake8 test-unit
-
-.PHONY: test-flake8
-test-flake8: virtualenv requirements-dev
-	${VIRTUALENV_ROOT}/bin/flake8 .
-
-.PHONY: test-unit
-test-unit: virtualenv requirements-dev
-	${VIRTUALENV_ROOT}/bin/py.test ${PYTEST_ARGS}
-
-.PHONY: docker-build
-docker-build:
-	$(if ${RELEASE_NAME},,$(eval export RELEASE_NAME=$(shell git describe)))
-	@echo "Building a docker image for ${RELEASE_NAME}..."
-	docker build -t digitalmarketplace/search-api --build-arg release_name=${RELEASE_NAME} .
-	docker tag digitalmarketplace/search-api digitalmarketplace/search-api:${RELEASE_NAME}
-
-.PHONY: docker-push
-docker-push:
-	$(if ${RELEASE_NAME},,$(eval export RELEASE_NAME=$(shell git describe)))
-	docker push digitalmarketplace/search-api:${RELEASE_NAME}
+.PHONY: bootstrap
+bootstrap:
+	pip install digitalmarketplace-developer-tools
+	@echo done
+	-@[ -z "$$TERM" ] || tput setaf 2  # green
+	@>&2 echo dmdevtools has been installed globally, run developer tasks with '`invoke`'
+	-@[ -z "$$TERM" ] || tput setaf 9  # default

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,1 @@
+from dmdevtools.invoke_tasks import api_app_tasks as ns


### PR DESCRIPTION
We want to be able to reduce duplication of code across our repos; one of the places we have a lot of duplicated code is in our Makefiles; all of our repos have very similar Makefiles with small historical differences.

This commit replaces Make with invoke, using the tasks from alphagov/digitalmarketplace-developer-tools.