### PR TITLE
Upgrade Flask to 1.1.4

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,8 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements.in
 
-Flask==1.0.4        # pyup: >=1.0.0,<1.1.0
-itsdangerous==1.1.0  # pyup: ignore
+Flask==1.0.4
+itsdangerous==1.1.0
 
 digitalmarketplace-utils
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,8 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements.in
 
-Flask==1.0.4
-itsdangerous==1.1.0
+Flask>=1.1,<2
+itsdangerous
 
 digitalmarketplace-utils
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ cryptography==3.3.2
     # via digitalmarketplace-utils
 defusedxml==0.6.0
     # via odfpy
-digitalmarketplace-utils==58.0.0
+digitalmarketplace-utils==59.0.0
     # via -r requirements.in
 docopt==0.6.2
     # via notifications-python-client
@@ -50,7 +50,7 @@ flask-session==0.3.2
     # via digitalmarketplace-utils
 flask-wtf==0.14.3
     # via digitalmarketplace-utils
-flask==1.0.4
+flask==1.1.4
     # via
     #   -r requirements.in
     #   digitalmarketplace-utils
@@ -81,7 +81,7 @@ jmespath==0.9.4
     # via
     #   boto3
     #   botocore
-mailchimp3==3.0.6
+mailchimp3==3.0.14
     # via digitalmarketplace-utils
 markupsafe==1.1.1
     # via jinja2
@@ -124,9 +124,7 @@ urllib3==1.25.10
     #   elasticsearch
     #   requests
 werkzeug==1.0.0
-    # via
-    #   digitalmarketplace-utils
-    #   flask
+    # via flask
 workdays==1.4
     # via digitalmarketplace-utils
 wtforms==2.2.1


### PR DESCRIPTION
Pin requirements to 1.1 or greater, but less than 2. Flask 1.1 is the last planned v1 release before 2.0.0, so take patch versions of 1.1 for security but not 2.0 which we're not ready for yet.

Take new versions of utils and content-loader which have been updated for Flask 1.1

Also remove the pin for itsdangerous - Flask now controls the supported versions. See https://github.com/pallets/flask/blob/1.1.4/setup.py#L58

Also remove pyup comments - we don't need them now we're using dependabot.

Essentially the same as alphagov/digitalmarketplace-supplier-frontend#1436

https://trello.com/c/obh5gpQp/2250-update-to-flask-114