### PR TITLE
Revert "Bump elasticsearch from 7.13.4 to 7.14.0"

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2021-08-13T09:26:39Z",
+  "generated_at": "2020-08-28T13:21:22Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -72,7 +72,7 @@
         "hashed_secret": "dea3c171abcdfb3e8380d6860630f618eb6e074f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 42,
+        "line_number": 57,
         "type": "Base64 High Entropy String"
       }
     ]

--- a/requirements.in
+++ b/requirements.in
@@ -7,5 +7,5 @@ itsdangerous
 digitalmarketplace-utils
 
 # Elasticsearch 5.0
-elasticsearch==7.14.0 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
+elasticsearch==7.13.4 # pyup: >=5.0.0,<6.0.0 # recommended by https://github.com/elastic/elasticsearch-py/blob/master/README
 Flask-Elasticsearch==0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ docopt==0.6.2
     # via notifications-python-client
 docutils==0.15.2
     # via botocore
-elasticsearch==7.14.0
+elasticsearch==7.13.4
     # via
     #   -r requirements.in
     #   flask-elasticsearch


### PR DESCRIPTION
Reverts alphagov/digitalmarketplace-search-api#303

This fails to deploy (https://ci.marketplace.team/job/release-app-paas/9217/consoleFull). This is because 7.14.0 dropped support for AWS Elasticsearch, which is what GOV.UK PaaS uses (https://github.com/elastic/elasticsearch-py/issues/1666)

`elasticsearch.exceptions.UnsupportedProductError: The client noticed that the server is not a supported distribution of Elasticsearch", "e": "500 Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.`

Let's revert to fix the build and then work out what we do about this.